### PR TITLE
Fix email domain whitelist empty config behavior

### DIFF
--- a/daylib/config.py
+++ b/daylib/config.py
@@ -351,10 +351,18 @@ class Settings(BaseSettings):
         """Get list of whitelisted email domains.
 
         Returns:
-            List of domain strings (lowercase), or empty list if all domains allowed.
+            List of domain strings (lowercase)
+            Empty list [] = allow all domains
+            ["__BLOCK_ALL__"] = block all domains (when empty string)
         """
-        if not self.whitelist_domains or self.whitelist_domains.strip().lower() == "all":
+        # Empty string = block all domains
+        if self.whitelist_domains == "":
+            return ["__BLOCK_ALL__"]
+
+        # "all" or "*" = allow all domains
+        if not self.whitelist_domains or self.whitelist_domains.strip().lower() in ("all", "*"):
             return []
+
         return [d.strip().lower() for d in self.whitelist_domains.split(",") if d.strip()]
 
     def is_domain_whitelisted(self, email: str) -> bool:
@@ -368,6 +376,11 @@ class Settings(BaseSettings):
             False if domain is blocked.
         """
         whitelist = self.get_whitelist_domains()
+
+        # Block all sentinel (when whitelist_domains="")
+        if whitelist == ["__BLOCK_ALL__"]:
+            return False
+
         if not whitelist:
             # No whitelist = all domains allowed
             return True


### PR DESCRIPTION
## Summary
Fixes a security issue where empty `whitelist_domains=""` was allowing all domains instead of blocking all.

## Changes
- **daylib/config.py**: Updated `get_whitelist_domains()` to return `__BLOCK_ALL__` sentinel when config is empty string
- **daylib/config.py**: Updated `is_domain_whitelisted()` to handle the block-all sentinel
- **Added**: Support for `*` as alternative to `all` for allowing all domains

## Behavior (now consistent with bloom and lsmc-atlas)
| Config Value | Behavior |
|-------------|----------|
| `""` (empty string) | Block all domains |
| `"all"` or `"*"` | Allow all domains |
| `"lsmc.bio,lsmc.com"` | Only allow listed domains |

## Testing
- Python syntax check passes (`python3 -m py_compile daylib/config.py`)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author