### PR TITLE
Feat: add /v1/ prefix to all API routes

### DIFF
--- a/daylib/workset_api.py
+++ b/daylib/workset_api.py
@@ -14,7 +14,7 @@ from typing import Any, Dict, Optional, Tuple
 
 import yaml  # type: ignore[import-untyped]
 
-from fastapi import Body, Depends, FastAPI, HTTPException, Query, Request, status
+from fastapi import APIRouter, Body, Depends, FastAPI, HTTPException, Query, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -763,6 +763,46 @@ def create_app(
             LOGGER.warning("Biospecimen endpoints will not be available")
     else:
         LOGGER.info("Biospecimen module not available - biospecimen API endpoints not registered")
+
+    # ========== API Versioning (v1) ==========
+    # Create a versioned router that mirrors all API routes under /v1/
+    # Original routes remain for backward compatibility.
+    v1_router = APIRouter(prefix="/v1", tags=["v1"])
+
+    # Always-available API routers
+    v1_router.include_router(worksets_router)
+    v1_router.include_router(mon_router)
+    v1_router.include_router(s3_router)
+    v1_router.include_router(cluster_router)
+
+    # Customer-dependent API routers
+    if customer_manager:
+        v1_router.include_router(cust_router)
+        v1_router.include_router(files_router)
+        v1_router.include_router(manifest_router)
+
+    # Template-dependent API routers (customer worksets, dashboard, billing)
+    if templates_dir.exists():
+        v1_router.include_router(cw_router)
+        v1_router.include_router(dash_router)
+        v1_router.include_router(billing_router)
+
+    # File management API router (conditional)
+    if file_registry and FILE_MANAGEMENT_AVAILABLE:
+        try:
+            v1_router.include_router(file_router)
+        except NameError:
+            pass  # file_router was not created due to earlier error
+
+    # Biospecimen API router (conditional)
+    if BIOSPECIMEN_AVAILABLE:
+        try:
+            v1_router.include_router(biospecimen_router)
+        except NameError:
+            pass  # biospecimen_router was not created due to earlier error
+
+    app.include_router(v1_router)
+    LOGGER.info("API v1 routes registered under /v1/ prefix")
 
     # Store settings in app state for access in route handlers
     app.state.settings = settings


### PR DESCRIPTION
## Summary

Adds API versioning by mounting all API routers under a `/v1/` prefix in addition to their existing paths.

### What changed

- Created a `v1_router` with `prefix="/v1"` in `workset_api.py`
- Included all 12 API routers under the v1 prefix
- Portal routes (HTML pages) are excluded from versioning
- All existing unversioned routes remain as backward-compatible aliases

### Route availability

Every API route is now accessible at both:
- `/worksets/...` (original, backward compat)
- `/v1/worksets/...` (versioned)
- `/api/customers/{id}/files/...` (original)
- `/v1/api/customers/{id}/files/...` (versioned)

### What's NOT versioned

- Portal routes (`/portal/...`) — HTML pages, not API
- Health endpoint (`/`) — stays at root

## Testing

- **785 passed, 0 failed** — full test suite clean
- 1 warning about duplicate OpenAPI operation IDs (expected — same routers mounted at two paths)

## Files changed

- `daylib/workset_api.py` (+41 lines)

---
PR opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author