### PR TITLE
Add global search and manifest/customer-region fixes

### DIFF
--- a/daylib/manifest_registry.py
+++ b/daylib/manifest_registry.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, List, Optional
 
 import boto3
 from botocore.exceptions import ClientError
-from boto3.dynamodb.conditions import Key
+from boto3.dynamodb.conditions import Attr, Key
 
 
 LOGGER = logging.getLogger("daylily.manifest_registry")
@@ -161,14 +161,78 @@ class ManifestRegistry:
         self.dynamodb = session.resource("dynamodb")
         self.table_name = table_name
         self.table = self.dynamodb.Table(table_name)
+        self._hash_key_name = "customer_id"
+        self._range_key_name: Optional[str] = "manifest_id"
+        self._schema_loaded = False
 
         LOGGER.info("ManifestRegistry bound to table: %s", self.table.table_name)
         assert hasattr(self.table, "table_name")
+
+    def _detect_table_schema(self) -> None:
+        """Detect key schema from DynamoDB and cache result.
+
+        Supports both legacy schema (customer_id + manifest_id) and pk-style tables.
+        Falls back to legacy schema when table metadata is unavailable.
+        """
+        if self._schema_loaded:
+            return
+
+        hash_key = "customer_id"
+        range_key: Optional[str] = "manifest_id"
+
+        try:
+            desc = self.dynamodb.meta.client.describe_table(TableName=self.table_name)
+            table_desc = desc.get("Table", {}) if isinstance(desc, dict) else {}
+            key_schema = table_desc.get("KeySchema", []) if isinstance(table_desc, dict) else []
+            if isinstance(key_schema, list):
+                for element in key_schema:
+                    if not isinstance(element, dict):
+                        continue
+                    attr_name = str(element.get("AttributeName") or "").strip()
+                    key_type = str(element.get("KeyType") or "").strip().upper()
+                    if key_type == "HASH" and attr_name:
+                        hash_key = attr_name
+                    elif key_type == "RANGE" and attr_name:
+                        range_key = attr_name
+                if not any(
+                    isinstance(element, dict) and str(element.get("KeyType", "")).upper() == "RANGE"
+                    for element in key_schema
+                ):
+                    range_key = None
+        except ClientError as e:
+            if e.response.get("Error", {}).get("Code") != "ResourceNotFoundException":
+                LOGGER.warning("Failed to inspect manifest table schema, using legacy defaults: %s", e)
+        except Exception as e:  # pragma: no cover - defensive
+            LOGGER.warning("Unexpected error inspecting manifest table schema, using legacy defaults: %s", e)
+
+        self._hash_key_name = hash_key
+        self._range_key_name = range_key
+        self._schema_loaded = True
+        LOGGER.info(
+            "Manifest table schema detected: hash=%s range=%s",
+            self._hash_key_name,
+            self._range_key_name or "(none)",
+        )
+
+    def _build_primary_key(self, customer_id: str, manifest_id: str) -> Dict[str, str]:
+        self._detect_table_schema()
+        if self._hash_key_name == "customer_id" and self._range_key_name == "manifest_id":
+            return {"customer_id": customer_id, "manifest_id": manifest_id}
+        if self._hash_key_name == "pk" and self._range_key_name == "sk":
+            return {"pk": f"manifest#{customer_id}", "sk": manifest_id}
+        if self._hash_key_name == "pk" and self._range_key_name is None:
+            return {"pk": f"manifest#{customer_id}#{manifest_id}"}
+        key = {self._hash_key_name: customer_id}
+        if self._range_key_name:
+            key[self._range_key_name] = manifest_id
+        return key
 
     def create_table_if_not_exists(self) -> None:
         try:
             self.table.load()
             LOGGER.info("Manifest table %s already exists", self.table_name)
+            self._schema_loaded = False
+            self._detect_table_schema()
             return
         except ClientError as e:
             if e.response["Error"]["Code"] != "ResourceNotFoundException":
@@ -189,6 +253,8 @@ class ManifestRegistry:
         )
         table.wait_until_exists()
         LOGGER.info("Manifest table %s created successfully", self.table_name)
+        self._schema_loaded = False
+        self._detect_table_schema()
 
     def save_manifest(
         self,
@@ -217,7 +283,7 @@ class ManifestRegistry:
                 "Consider splitting into multiple manifests."
             )
 
-        item = {
+        item: Dict[str, Any] = {
             "customer_id": customer_id,
             "manifest_id": manifest_id,
             "created_at": created_at,
@@ -227,12 +293,23 @@ class ManifestRegistry:
             "tsv_sha256": tsv_sha256,
             "tsv_gzip_b64": tsv_gzip_b64,
             "schema_version": 1,
+            "entity_type": "manifest",
         }
+        item.update(self._build_primary_key(customer_id, manifest_id))
+
+        self._detect_table_schema()
+        if self._range_key_name:
+            condition_expr = (
+                f"attribute_not_exists({self._hash_key_name}) AND "
+                f"attribute_not_exists({self._range_key_name})"
+            )
+        else:
+            condition_expr = f"attribute_not_exists({self._hash_key_name})"
 
         try:
             self.table.put_item(
                 Item=item,
-                ConditionExpression="attribute_not_exists(customer_id) AND attribute_not_exists(manifest_id)",
+                ConditionExpression=condition_expr,
             )
         except ClientError as e:
             if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
@@ -263,17 +340,51 @@ class ManifestRegistry:
         if not customer_id or not customer_id.strip():
             raise ValueError("customer_id is required")
 
+        self._detect_table_schema()
+        items: List[Dict[str, Any]] = []
+
         try:
-            resp = self.table.query(
-                KeyConditionExpression=Key("customer_id").eq(customer_id),
-                Limit=limit,
-                ScanIndexForward=False,  # newest-first due to time-sortable manifest_id
-            )
+            if self._hash_key_name == "customer_id":
+                resp = self.table.query(
+                    KeyConditionExpression=Key("customer_id").eq(customer_id),
+                    Limit=limit,
+                    ScanIndexForward=False,  # newest-first due to time-sortable manifest_id
+                )
+                items = resp.get("Items", [])
+            elif self._hash_key_name == "pk" and self._range_key_name == "sk":
+                resp = self.table.query(
+                    KeyConditionExpression=Key("pk").eq(f"manifest#{customer_id}"),
+                    Limit=limit,
+                    ScanIndexForward=False,
+                )
+                items = resp.get("Items", [])
+            else:
+                # Fallback for pk-only and other schemas without customer queryability.
+                # Filter by stored customer_id attribute and manifest entity type.
+                scan_kwargs: Dict[str, Any] = {
+                    "FilterExpression": Attr("customer_id").eq(customer_id)
+                    & Attr("entity_type").eq("manifest"),
+                }
+                last_evaluated_key = None
+                while len(items) < limit:
+                    if last_evaluated_key:
+                        scan_kwargs["ExclusiveStartKey"] = last_evaluated_key
+                    resp = self.table.scan(**scan_kwargs)
+                    page_items = resp.get("Items", [])
+                    items.extend(page_items)
+                    last_evaluated_key = resp.get("LastEvaluatedKey")
+                    if not last_evaluated_key:
+                        break
+                items = items[:limit]
         except ClientError as e:
             LOGGER.error("Failed to list manifests for customer %s: %s", customer_id, str(e))
             raise
 
-        items = resp.get("Items", [])
+        items = sorted(
+            items,
+            key=lambda it: str(it.get("created_at") or it.get("manifest_id") or ""),
+            reverse=True,
+        )
         result = []
         for it in items:
             result.append(
@@ -294,10 +405,9 @@ class ManifestRegistry:
         if not manifest_id or not manifest_id.strip():
             raise ValueError("manifest_id is required")
 
+        key = self._build_primary_key(customer_id, manifest_id)
         try:
-            resp = self.table.get_item(
-                Key={"customer_id": customer_id, "manifest_id": manifest_id}
-            )
+            resp = self.table.get_item(Key=key)
         except ClientError as e:
             LOGGER.error(
                 "Failed to get manifest %s for customer %s: %s",

--- a/daylib/routes/portal.py
+++ b/daylib/routes/portal.py
@@ -38,6 +38,7 @@ from daylily_cognito.oauth import (
 from daylib.security import sanitize_for_log
 from daylib.s3_utils import RegionAwareS3Client
 from daylib.file_registry import detect_file_format as _detect_file_format
+from daylib.search import search_portal
 from daylib.routes.dependencies import (
     convert_customer_for_template,
     format_file_size,
@@ -83,6 +84,7 @@ class PortalDependencies:
         file_registry: Optional[Any] = None,
         linked_bucket_manager: Optional[Any] = None,
         biospecimen_registry: Optional[Any] = None,
+        manifest_registry: Optional[Any] = None,
     ):
         self.state_db = state_db
         self.templates = templates
@@ -93,6 +95,7 @@ class PortalDependencies:
         self.file_registry = file_registry
         self.linked_bucket_manager = linked_bucket_manager
         self.biospecimen_registry = biospecimen_registry
+        self.manifest_registry = manifest_registry
         self.region = settings.get_effective_region()
         self.profile = settings.aws_profile
 
@@ -139,6 +142,8 @@ def _get_template_context(request: Request, deps: PortalDependencies, **kwargs) 
             context["is_admin"] = request.session.get("is_admin", False)
     # Apply kwargs last so explicit values take precedence
     context.update(kwargs)
+    if context.get("user_authenticated") and "search_scope" not in context:
+        context["search_scope"] = "all" if bool(context.get("is_admin", False)) else "mine"
     return context
 
 
@@ -408,6 +413,83 @@ def _extract_workset_storage(workset: Dict[str, Any]) -> Dict[str, Any]:
     return _extract_workset_metrics(workset)
 
 
+SEARCH_TYPE_LABELS: Dict[str, str] = {
+    "workset": "Worksets",
+    "file": "Files",
+    "subject": "Subjects",
+    "biosample": "Biosamples",
+    "library": "Libraries",
+    "manifest": "Manifests",
+    "cluster": "Clusters",
+    "user": "Users",
+    "monitor_log": "Monitor Logs",
+}
+
+
+def _query_list(request: Request, key: str) -> List[str]:
+    """Parse repeatable query params and comma-separated values."""
+    values: List[str] = []
+    for raw_value in request.query_params.getlist(key):
+        raw = str(raw_value or "").strip()
+        if not raw:
+            continue
+        for part in raw.split(","):
+            token = part.strip()
+            if token:
+                values.append(token)
+    return values
+
+
+def _build_portal_search_filters(request: Request, *, is_admin: bool) -> Dict[str, Any]:
+    """Build normalized search filters from request query params."""
+    scope_default = "all" if is_admin else "mine"
+    scope = str(request.query_params.get("scope") or scope_default).strip().lower()
+    limit_raw = str(request.query_params.get("limit_per_type") or "").strip()
+    limit_per_type = 20
+    if limit_raw:
+        try:
+            limit_per_type = int(limit_raw)
+        except ValueError:
+            limit_per_type = 20
+
+    return {
+        "scope": scope,
+        "types": _query_list(request, "type"),
+        "state": str(request.query_params.get("state") or "").strip(),
+        "region": str(request.query_params.get("region") or "").strip(),
+        "customer": str(request.query_params.get("customer") or "").strip(),
+        "tag": _query_list(request, "tag"),
+        "file_format": str(request.query_params.get("file_format") or "").strip(),
+        "sample_type": str(request.query_params.get("sample_type") or "").strip(),
+        "platform": str(request.query_params.get("platform") or "").strip(),
+        "limit_per_type": limit_per_type,
+    }
+
+
+def _execute_portal_search(request: Request, deps: PortalDependencies) -> Dict[str, Any]:
+    """Run global portal search with request/session-derived context."""
+    session_context = {
+        "customer_id": request.session.get("customer_id", ""),
+        "user_email": request.session.get("user_email", ""),
+        "is_admin": bool(request.session.get("is_admin", False)),
+    }
+    filters = _build_portal_search_filters(request, is_admin=bool(session_context["is_admin"]))
+    query = str(request.query_params.get("q") or "").strip()
+    return search_portal(
+        query=query,
+        filters=filters,
+        session_context=session_context,
+        deps={
+            "state_db": deps.state_db,
+            "settings": deps.settings,
+            "customer_manager": deps.customer_manager,
+            "file_registry": deps.file_registry,
+            "biospecimen_registry": deps.biospecimen_registry,
+            "manifest_registry": deps.manifest_registry,
+        },
+    )
+
+
 def create_portal_router(deps: PortalDependencies) -> APIRouter:
     """Create portal router with injected dependencies.
 
@@ -556,6 +638,68 @@ def create_portal_router(deps: PortalDependencies) -> APIRouter:
             "dashboard.html",
             _get_template_context(request, deps, customer=customer, worksets=worksets, stats=stats, active_page="dashboard"),
         )
+
+    # ========== Global Search Routes ==========
+
+    @router.get("/portal/search", response_class=HTMLResponse)
+    async def portal_search(request: Request):
+        """Global federated search results page."""
+        auth_redirect = _require_portal_auth(request)
+        if auth_redirect:
+            return auth_redirect
+
+        customer, _ = _get_customer_for_session(request, deps)
+        search_data = _execute_portal_search(request, deps)
+
+        displayed_types = list(search_data.get("types", []))
+        selected_types = set(displayed_types)
+        type_facets = [
+            {
+                "key": item_type,
+                "label": SEARCH_TYPE_LABELS.get(item_type, item_type.replace("_", " ").title()),
+                "count": int(search_data.get("returned_counts", {}).get(item_type, 0)),
+                "selected": item_type in selected_types,
+            }
+            for item_type in displayed_types
+        ]
+
+        filters = search_data.get("filters", {})
+        has_query = bool(str(search_data.get("query") or "").strip())
+        has_filters = any(
+            [
+                filters.get("types"),
+                filters.get("state"),
+                filters.get("region"),
+                filters.get("customer"),
+                filters.get("tags"),
+                filters.get("file_format"),
+                filters.get("sample_type"),
+                filters.get("platform"),
+            ]
+        )
+
+        return deps.templates.TemplateResponse(
+            request,
+            "search/results.html",
+            _get_template_context(
+                request,
+                deps,
+                customer=customer,
+                search=search_data,
+                type_facets=type_facets,
+                type_labels=SEARCH_TYPE_LABELS,
+                has_query=has_query,
+                has_filters=has_filters,
+                active_page="search",
+                search_scope=search_data.get("scope", "mine"),
+            ),
+        )
+
+    @router.get("/api/portal/search")
+    async def portal_api_search(request: Request):
+        """JSON global search endpoint used by portal clients."""
+        _require_portal_api_session(request)
+        return JSONResponse(_execute_portal_search(request, deps))
 
     # ========== Authentication Routes ==========
 
@@ -2627,7 +2771,11 @@ def create_portal_router(deps: PortalDependencies) -> APIRouter:
 
     @router.get("/portal/biospecimen", response_class=HTMLResponse)
     @router.get("/portal/biospecimen/subjects", response_class=HTMLResponse)
-    async def portal_biospecimen_subjects(request: Request):
+    async def portal_biospecimen_subjects(
+        request: Request,
+        q: Optional[str] = None,
+        subject_id: Optional[str] = None,
+    ):
         """Subjects management page."""
         auth_redirect = _require_portal_auth(request)
         if auth_redirect:
@@ -2673,10 +2821,40 @@ def create_portal_router(deps: PortalDependencies) -> APIRouter:
             except Exception as e:
                 LOGGER.warning(f"Failed to load subjects from biospecimen registry: {e}")
 
+        query_text = str(q or "").strip().lower()
+        subject_id_filter = str(subject_id or "").strip().lower()
+
+        if subject_id_filter:
+            subjects = [
+                subj
+                for subj in subjects
+                if subject_id_filter in str(subj.get("subject_id", "")).lower()
+                or subject_id_filter in str(subj.get("identifier", "")).lower()
+            ]
+        if query_text:
+            subjects = [
+                subj
+                for subj in subjects
+                if query_text in str(subj.get("subject_id", "")).lower()
+                or query_text in str(subj.get("identifier", "")).lower()
+                or query_text in str(subj.get("display_name", "")).lower()
+                or query_text in str(subj.get("cohort", "")).lower()
+                or query_text in str(subj.get("sex", "")).lower()
+            ]
+
         return deps.templates.TemplateResponse(
             request,
             "biospecimen/subjects.html",
-            _get_template_context(request, deps, customer=customer, subjects=subjects, stats=stats, active_page="biospecimen"),
+            _get_template_context(
+                request,
+                deps,
+                customer=customer,
+                subjects=subjects,
+                stats=stats,
+                subject_query=q or "",
+                subject_id_filter=subject_id or "",
+                active_page="biospecimen",
+            ),
         )
 
     # ========== Account Routes ==========
@@ -3004,6 +3182,7 @@ def create_portal_router(deps: PortalDependencies) -> APIRouter:
         request: Request,
         error: Optional[str] = None,
         success: Optional[str] = None,
+        q: Optional[str] = None,
     ):
         """Admin: manage portal users (customers)."""
         auth_redirect = _require_portal_auth(request)
@@ -3022,6 +3201,16 @@ def create_portal_router(deps: PortalDependencies) -> APIRouter:
                 LOGGER.error("Failed to list customers: %s", e)
                 error = error or "Failed to list customers"
 
+        query_text = str(q or "").strip().lower()
+        if query_text:
+            customers = [
+                customer_item
+                for customer_item in customers
+                if query_text in str(getattr(customer_item, "email", "")).lower()
+                or query_text in str(getattr(customer_item, "customer_id", "")).lower()
+                or query_text in str(getattr(customer_item, "customer_name", "")).lower()
+            ]
+
         return deps.templates.TemplateResponse(
             request,
             "admin/users.html",
@@ -3032,6 +3221,7 @@ def create_portal_router(deps: PortalDependencies) -> APIRouter:
                 customers=customers,
                 error=error,
                 success=success,
+                user_query=q or "",
                 active_page="admin_users",
             ),
         )

--- a/daylib/search/__init__.py
+++ b/daylib/search/__init__.py
@@ -1,0 +1,5 @@
+"""Search services for portal and API interfaces."""
+
+from daylib.search.global_search import search_portal
+
+__all__ = ["search_portal"]

--- a/daylib/search/global_search.py
+++ b/daylib/search/global_search.py
@@ -1,0 +1,1381 @@
+"""Federated global search for portal entities.
+
+This module provides a single search entrypoint used by both HTML and JSON
+portal search routes. It aggregates results across multiple system domains
+without introducing a dedicated search index table.
+"""
+
+from __future__ import annotations
+
+import logging
+import shlex
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
+from urllib.parse import quote_plus
+
+from daylib.routes.dependencies import verify_workset_access
+from daylib.workset_state_db import WorksetState
+
+LOGGER = logging.getLogger("daylily.search.global")
+
+ALL_TYPES: Set[str] = {
+    "workset",
+    "file",
+    "subject",
+    "biosample",
+    "library",
+    "manifest",
+    "cluster",
+    "user",
+    "monitor_log",
+}
+ADMIN_ONLY_TYPES: Set[str] = {"user", "monitor_log"}
+
+DEFAULT_LIMIT_PER_TYPE = 20
+MAX_LIMIT_PER_TYPE = 100
+MAX_CUSTOMERS_SCOPE_ALL = 200
+MAX_CANDIDATES_PER_TYPE = 500
+MAX_MONITOR_LINES = 2000
+
+SUPPORTED_OPERATORS: Set[str] = {
+    "type",
+    "state",
+    "region",
+    "customer",
+    "tag",
+    "file_format",
+    "sample_type",
+    "platform",
+}
+
+
+@dataclass
+class ParsedQuery:
+    """Represents parsed search query text and inline operators."""
+
+    terms: List[str] = field(default_factory=list)
+    operators: Dict[str, List[str]] = field(default_factory=dict)
+
+    @property
+    def free_text(self) -> str:
+        return " ".join(self.terms).strip()
+
+
+@dataclass
+class SearchScope:
+    """Session-derived scope and identity context."""
+
+    customer_id: str
+    user_email: str
+    is_admin: bool
+    requested_scope: str
+
+
+def _to_str(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _to_lower(value: Any) -> str:
+    return _to_str(value).strip().lower()
+
+
+def _listify(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return [_to_str(v).strip() for v in value if _to_str(v).strip()]
+    raw = _to_str(value).strip()
+    return [raw] if raw else []
+
+
+def _normalize_type(value: str) -> str:
+    normalized = _to_lower(value)
+    if normalized.endswith("s") and normalized[:-1] in ALL_TYPES:
+        return normalized[:-1]
+    aliases = {
+        "worksets": "workset",
+        "files": "file",
+        "subjects": "subject",
+        "biosamples": "biosample",
+        "libraries": "library",
+        "manifests": "manifest",
+        "clusters": "cluster",
+        "users": "user",
+        "monitor": "monitor_log",
+        "logs": "monitor_log",
+        "monitor_logs": "monitor_log",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def _parse_iso_to_ts(value: Any) -> float:
+    text = _to_str(value).strip()
+    if not text:
+        return 0.0
+    try:
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        return datetime.fromisoformat(text).timestamp()
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _parse_query(query: str) -> ParsedQuery:
+    parsed = ParsedQuery(operators={op: [] for op in SUPPORTED_OPERATORS})
+    if not query or not query.strip():
+        return parsed
+
+    try:
+        tokens = shlex.split(query)
+    except ValueError:
+        # Fallback to split when user input has unmatched quotes.
+        tokens = query.split()
+
+    for token in tokens:
+        if ":" in token:
+            key, raw_value = token.split(":", 1)
+            key_l = key.strip().lower()
+            value = raw_value.strip()
+            if key_l in SUPPORTED_OPERATORS and value:
+                parsed.operators[key_l].append(value)
+                continue
+        parsed.terms.append(token)
+
+    # Remove empty operator buckets for cleaner payloads
+    parsed.operators = {k: v for k, v in parsed.operators.items() if v}
+    return parsed
+
+
+def _resolve_scope(filters: Dict[str, Any], session_context: Dict[str, Any], warnings: List[str]) -> SearchScope:
+    is_admin = bool(session_context.get("is_admin", False))
+    requested = _to_lower(filters.get("scope") or ("all" if is_admin else "mine"))
+    if requested not in {"all", "mine"}:
+        warnings.append(f"Invalid scope '{requested}', falling back to default scope")
+        requested = "all" if is_admin else "mine"
+
+    effective = requested
+    if not is_admin and requested == "all":
+        effective = "mine"
+        warnings.append("Non-admin searches are always restricted to scope=mine")
+
+    return SearchScope(
+        customer_id=_to_str(session_context.get("customer_id")),
+        user_email=_to_str(session_context.get("user_email")),
+        is_admin=is_admin,
+        requested_scope=effective,
+    )
+
+
+def _extract_filters(filters: Dict[str, Any], parsed_query: ParsedQuery) -> Dict[str, Any]:
+    def _first(name: str) -> str:
+        explicit = _to_str(filters.get(name)).strip()
+        if explicit:
+            return explicit
+        op_values = parsed_query.operators.get(name, [])
+        return op_values[0].strip() if op_values else ""
+
+    combined_types = set(_normalize_type(t) for t in _listify(filters.get("types")))
+    combined_types.update(_normalize_type(t) for t in parsed_query.operators.get("type", []))
+    combined_types = {t for t in combined_types if t}
+
+    tags = [t.lower() for t in _listify(filters.get("tag"))]
+    tags.extend(_to_lower(t) for t in parsed_query.operators.get("tag", []))
+    tags = [t for t in tags if t]
+
+    return {
+        "types": sorted(combined_types),
+        "state": _to_lower(_first("state")),
+        "region": _to_lower(_first("region")),
+        "customer": _to_lower(_first("customer")),
+        "tags": tags,
+        "file_format": _to_lower(_first("file_format")),
+        "sample_type": _to_lower(_first("sample_type")),
+        "platform": _to_lower(_first("platform")),
+    }
+
+
+def _resolve_requested_types(extracted_filters: Dict[str, Any], scope: SearchScope, warnings: List[str]) -> Set[str]:
+    requested = set(extracted_filters.get("types") or [])
+    if not requested:
+        requested = set(ALL_TYPES)
+
+    unknown = {t for t in requested if t not in ALL_TYPES}
+    if unknown:
+        warnings.append(f"Ignoring unknown type filters: {', '.join(sorted(unknown))}")
+        requested = {t for t in requested if t in ALL_TYPES}
+
+    if not scope.is_admin:
+        requested -= ADMIN_ONLY_TYPES
+
+    return requested
+
+
+def _prepare_customer_targets(
+    scope: SearchScope,
+    extracted_filters: Dict[str, Any],
+    customer_manager: Optional[Any],
+    warnings: List[str],
+) -> Tuple[List[str], Dict[str, str]]:
+    customer_filter = _to_lower(extracted_filters.get("customer"))
+    customer_email_map: Dict[str, str] = {}
+
+    if scope.requested_scope == "mine":
+        if not scope.customer_id:
+            warnings.append("Session has no customer_id; customer-scoped results may be empty")
+            return [], customer_email_map
+        if customer_filter and not _matches_customer_filter(scope.customer_id, scope.user_email, customer_filter):
+            return [], customer_email_map
+        customer_email_map[scope.customer_id] = scope.user_email
+        return [scope.customer_id], customer_email_map
+
+    # scope=all for admin
+    if not customer_manager:
+        warnings.append("Customer manager unavailable; falling back to current session customer")
+        if scope.customer_id:
+            customer_email_map[scope.customer_id] = scope.user_email
+            return [scope.customer_id], customer_email_map
+        return [], customer_email_map
+
+    try:
+        customers = customer_manager.list_customers()
+    except Exception as exc:  # pragma: no cover - defensive
+        LOGGER.warning("Failed to enumerate customers for scope=all search: %s", exc)
+        warnings.append("Failed to enumerate customers for scope=all; falling back to session customer")
+        if scope.customer_id:
+            customer_email_map[scope.customer_id] = scope.user_email
+            return [scope.customer_id], customer_email_map
+        return [], customer_email_map
+
+    customer_ids: List[str] = []
+    for customer in customers:
+        cid = _to_str(getattr(customer, "customer_id", ""))
+        email = _to_str(getattr(customer, "email", ""))
+        if not cid:
+            continue
+
+        if customer_filter:
+            cname = _to_lower(getattr(customer, "customer_name", ""))
+            if (
+                customer_filter not in cid.lower()
+                and customer_filter not in email.lower()
+                and customer_filter not in cname
+            ):
+                continue
+
+        customer_ids.append(cid)
+        customer_email_map[cid] = email
+
+        if len(customer_ids) >= MAX_CUSTOMERS_SCOPE_ALL:
+            warnings.append(
+                f"Customer scope limited to first {MAX_CUSTOMERS_SCOPE_ALL} matches for performance"
+            )
+            break
+
+    if not customer_ids and scope.customer_id:
+        customer_ids = [scope.customer_id]
+        customer_email_map[scope.customer_id] = scope.user_email
+
+    return customer_ids, customer_email_map
+
+
+def _matches_customer_filter(customer_id: str, customer_email: str, customer_filter: str) -> bool:
+    if not customer_filter:
+        return True
+    token = customer_filter.lower()
+    return token in customer_id.lower() or token in customer_email.lower()
+
+
+def _all_tags_present(available_tags: Sequence[str], required_tags: Sequence[str]) -> bool:
+    if not required_tags:
+        return True
+    normalized = {_to_lower(tag) for tag in available_tags if _to_lower(tag)}
+    return all(required in normalized for required in required_tags)
+
+
+def _match_terms(terms: Sequence[str], field_map: Dict[str, str]) -> Tuple[bool, float, List[str]]:
+    if not terms:
+        return True, 1.0, []
+
+    score = 0.0
+    matched_fields: Set[str] = set()
+
+    for raw_term in terms:
+        term = _to_lower(raw_term)
+        if not term:
+            continue
+
+        term_found = False
+        term_score = 0.0
+
+        for field_name, value in field_map.items():
+            haystack = _to_lower(value)
+            if not haystack:
+                continue
+
+            candidate_score = 0.0
+            if haystack == term:
+                candidate_score = 12.0
+            elif any(part == term for part in haystack.replace("/", " ").replace("_", " ").replace("-", " ").split()):
+                candidate_score = 11.0
+            elif haystack.startswith(term):
+                candidate_score = 9.0
+            elif f" {term}" in haystack:
+                candidate_score = 7.0
+            elif term in haystack:
+                candidate_score = 5.0
+
+            if candidate_score > 0:
+                term_found = True
+                term_score = max(term_score, candidate_score)
+                matched_fields.add(field_name)
+
+        if not term_found:
+            return False, 0.0, []
+
+        score += term_score
+
+    if len(terms) > 1:
+        score += 1.0
+
+    return True, score, sorted(matched_fields)
+
+
+def _sort_and_limit_hits(hits: List[Dict[str, Any]], limit_per_type: int) -> Tuple[List[Dict[str, Any]], bool]:
+    sorted_hits = sorted(
+        hits,
+        key=lambda item: (
+            float(item.get("score", 0.0)),
+            _parse_iso_to_ts(item.get("created_at")),
+        ),
+        reverse=True,
+    )
+    truncated = len(sorted_hits) > limit_per_type
+    return sorted_hits[:limit_per_type], truncated
+
+
+def _build_hit(
+    *,
+    hit_id: str,
+    hit_type: str,
+    title: str,
+    subtitle: str,
+    url: str,
+    customer_id: str,
+    badges: Sequence[str],
+    score: float,
+    matched_fields: Sequence[str],
+    created_at: str,
+) -> Dict[str, Any]:
+    return {
+        "id": hit_id,
+        "type": hit_type,
+        "title": title,
+        "subtitle": subtitle,
+        "url": url,
+        "customer_id": customer_id,
+        "badges": [b for b in badges if b],
+        "score": round(score, 4),
+        "matched_fields": list(matched_fields),
+        "created_at": created_at,
+    }
+
+
+def _search_worksets(
+    *,
+    parsed_query: ParsedQuery,
+    extracted_filters: Dict[str, Any],
+    scope: SearchScope,
+    customer_ids: Sequence[str],
+    customer_email_map: Dict[str, str],
+    deps: Dict[str, Any],
+    candidate_cap: int,
+) -> Tuple[List[Dict[str, Any]], List[str], Dict[str, int]]:
+    warnings: List[str] = []
+    hits: List[Dict[str, Any]] = []
+    candidates = 0
+
+    state_db = deps.get("state_db")
+    if state_db is None:
+        warnings.append("Workset database unavailable")
+        return [], warnings, {"candidates": 0, "matched": 0}
+
+    state_filter = _to_lower(extracted_filters.get("state"))
+    region_filter = _to_lower(extracted_filters.get("region"))
+    customer_filter = _to_lower(extracted_filters.get("customer"))
+
+    state_obj: Optional[WorksetState] = None
+    if state_filter:
+        for ws_state in WorksetState:
+            if ws_state.value == state_filter:
+                state_obj = ws_state
+                break
+        if state_obj is None:
+            # Invalid state means no workset matches
+            return [], warnings, {"candidates": 0, "matched": 0}
+
+    for customer_id in customer_ids:
+        if not _matches_customer_filter(customer_id, customer_email_map.get(customer_id, ""), customer_filter):
+            continue
+
+        try:
+            batch = state_db.list_worksets_by_customer(customer_id, state=state_obj, limit=candidate_cap)
+        except Exception as exc:  # pragma: no cover - defensive
+            warnings.append(f"Failed to query worksets for customer '{customer_id}'")
+            LOGGER.warning("Workset search failed for customer %s: %s", customer_id, exc)
+            continue
+
+        if len(batch) >= candidate_cap:
+            warnings.append(f"Workset candidate cap reached for customer '{customer_id}'")
+
+        for workset in batch:
+            candidates += 1
+            if not verify_workset_access(
+                workset,
+                customer_id=scope.customer_id,
+                user_email=scope.user_email,
+                is_admin=scope.is_admin,
+            ):
+                continue
+
+            ws_id = _to_str(workset.get("workset_id"))
+            ws_name = _to_str(workset.get("name"))
+            ws_state = _to_str(workset.get("state"))
+            metadata = workset.get("metadata") if isinstance(workset.get("metadata"), dict) else {}
+
+            ws_region = _to_lower(
+                workset.get("execution_cluster_region")
+                or workset.get("cluster_region")
+                or metadata.get("cluster_region")
+                or ""
+            )
+            if region_filter and ws_region != region_filter:
+                continue
+
+            if state_filter and _to_lower(ws_state) != state_filter:
+                continue
+
+            tags = [
+                _to_str(metadata.get("workset_type")),
+                _to_str(metadata.get("pipeline_type")),
+                _to_str(metadata.get("reference_genome")),
+            ]
+            if not _all_tags_present(tags, extracted_filters.get("tags", [])):
+                continue
+
+            fields = {
+                "workset_id": ws_id,
+                "name": ws_name,
+                "state": ws_state,
+                "workset_type": _to_str(metadata.get("workset_type")),
+                "pipeline_type": _to_str(metadata.get("pipeline_type")),
+                "notification_email": _to_str(metadata.get("notification_email")),
+                "submitted_by": _to_str(metadata.get("submitted_by")),
+                "customer_id": _to_str(workset.get("customer_id")),
+            }
+            matched, score, matched_fields = _match_terms(parsed_query.terms, fields)
+            if not matched:
+                continue
+
+            subtitle_parts = [ws_state or "unknown"]
+            if fields["pipeline_type"]:
+                subtitle_parts.append(fields["pipeline_type"])
+            subtitle_parts.append(ws_id)
+            if ws_region:
+                subtitle_parts.append(ws_region)
+
+            hit = _build_hit(
+                hit_id=ws_id,
+                hit_type="workset",
+                title=ws_name or ws_id,
+                subtitle=" • ".join(part for part in subtitle_parts if part),
+                url=f"/portal/worksets/{quote_plus(ws_id)}",
+                customer_id=_to_str(workset.get("customer_id")) or customer_id,
+                badges=[ws_state, fields["workset_type"], ws_region],
+                score=score,
+                matched_fields=matched_fields,
+                created_at=_to_str(workset.get("created_at")),
+            )
+            hits.append(hit)
+
+    return hits, warnings, {"candidates": candidates, "matched": len(hits)}
+
+
+def _search_files(
+    *,
+    parsed_query: ParsedQuery,
+    extracted_filters: Dict[str, Any],
+    customer_ids: Sequence[str],
+    customer_email_map: Dict[str, str],
+    deps: Dict[str, Any],
+    candidate_cap: int,
+) -> Tuple[List[Dict[str, Any]], List[str], Dict[str, int]]:
+    warnings: List[str] = []
+    hits: List[Dict[str, Any]] = []
+    candidates = 0
+
+    file_registry = deps.get("file_registry")
+    if file_registry is None:
+        warnings.append("File registry unavailable")
+        return [], warnings, {"candidates": 0, "matched": 0}
+
+    customer_filter = _to_lower(extracted_filters.get("customer"))
+    required_tags = extracted_filters.get("tags", [])
+    file_format_filter = _to_lower(extracted_filters.get("file_format"))
+    sample_type_filter = _to_lower(extracted_filters.get("sample_type"))
+    platform_filter = _to_lower(extracted_filters.get("platform"))
+
+    for customer_id in customer_ids:
+        if not _matches_customer_filter(customer_id, customer_email_map.get(customer_id, ""), customer_filter):
+            continue
+
+        try:
+            files = file_registry.list_customer_files(customer_id, limit=candidate_cap)
+        except Exception as exc:  # pragma: no cover - defensive
+            warnings.append(f"Failed to query files for customer '{customer_id}'")
+            LOGGER.warning("File search failed for customer %s: %s", customer_id, exc)
+            continue
+
+        if len(files) >= candidate_cap:
+            warnings.append(f"File candidate cap reached for customer '{customer_id}'")
+
+        for file_reg in files:
+            candidates += 1
+
+            file_id = _to_str(getattr(file_reg, "file_id", ""))
+            file_customer_id = _to_str(getattr(file_reg, "customer_id", "")) or customer_id
+            file_meta = getattr(file_reg, "file_metadata", None)
+            seq_meta = getattr(file_reg, "sequencing_metadata", None)
+            bio_meta = getattr(file_reg, "biosample_metadata", None)
+            tags = getattr(file_reg, "tags", []) or []
+
+            s3_uri = _to_str(getattr(file_meta, "s3_uri", ""))
+            filename = s3_uri.rsplit("/", 1)[-1] if s3_uri else ""
+            file_format = _to_lower(getattr(file_meta, "file_format", ""))
+            sample_type = _to_lower(getattr(bio_meta, "sample_type", ""))
+            platform = _to_lower(getattr(seq_meta, "platform", ""))
+
+            if file_format_filter and file_format != file_format_filter:
+                continue
+            if sample_type_filter and sample_type != sample_type_filter:
+                continue
+            if platform_filter and platform_filter not in platform:
+                continue
+            if not _all_tags_present(tags, required_tags):
+                continue
+
+            fields = {
+                "file_id": file_id,
+                "filename": filename,
+                "s3_uri": s3_uri,
+                "subject_id": _to_str(getattr(bio_meta, "subject_id", "")),
+                "biosample_id": _to_str(getattr(bio_meta, "biosample_id", "")),
+                "tags": " ".join(_to_str(t) for t in tags),
+                "file_format": file_format,
+                "sample_type": sample_type,
+                "platform": platform,
+                "customer_id": file_customer_id,
+            }
+            matched, score, matched_fields = _match_terms(parsed_query.terms, fields)
+            if not matched:
+                continue
+
+            subtitle_parts = [filename or file_id]
+            if fields["subject_id"]:
+                subtitle_parts.append(f"subject:{fields['subject_id']}")
+            if file_format:
+                subtitle_parts.append(file_format)
+
+            hit = _build_hit(
+                hit_id=file_id,
+                hit_type="file",
+                title=filename or file_id,
+                subtitle=" • ".join(subtitle_parts),
+                url=f"/portal/files/{quote_plus(file_id)}",
+                customer_id=file_customer_id,
+                badges=[file_format, sample_type, platform],
+                score=score,
+                matched_fields=matched_fields,
+                created_at=_to_str(getattr(file_reg, "registered_at", "")),
+            )
+            hits.append(hit)
+
+    return hits, warnings, {"candidates": candidates, "matched": len(hits)}
+
+
+def _search_subjects(
+    *,
+    parsed_query: ParsedQuery,
+    extracted_filters: Dict[str, Any],
+    customer_ids: Sequence[str],
+    customer_email_map: Dict[str, str],
+    deps: Dict[str, Any],
+    candidate_cap: int,
+) -> Tuple[List[Dict[str, Any]], List[str], Dict[str, int]]:
+    warnings: List[str] = []
+    hits: List[Dict[str, Any]] = []
+    candidates = 0
+
+    registry = deps.get("biospecimen_registry")
+    if registry is None:
+        warnings.append("Biospecimen registry unavailable")
+        return [], warnings, {"candidates": 0, "matched": 0}
+
+    customer_filter = _to_lower(extracted_filters.get("customer"))
+    required_tags = extracted_filters.get("tags", [])
+
+    for customer_id in customer_ids:
+        if not _matches_customer_filter(customer_id, customer_email_map.get(customer_id, ""), customer_filter):
+            continue
+
+        try:
+            subjects = registry.list_subjects(customer_id, limit=candidate_cap)
+        except Exception as exc:  # pragma: no cover - defensive
+            warnings.append(f"Failed to query subjects for customer '{customer_id}'")
+            LOGGER.warning("Subject search failed for customer %s: %s", customer_id, exc)
+            continue
+
+        if len(subjects) >= candidate_cap:
+            warnings.append(f"Subject candidate cap reached for customer '{customer_id}'")
+
+        for subject in subjects:
+            candidates += 1
+            subject_tags = list(getattr(subject, "tags", []) or [])
+            if not _all_tags_present(subject_tags, required_tags):
+                continue
+
+            subject_id = _to_str(getattr(subject, "subject_id", ""))
+            identifier = _to_str(getattr(subject, "identifier", ""))
+            display_name = _to_str(getattr(subject, "display_name", ""))
+            cohort = _to_str(getattr(subject, "cohort", ""))
+
+            fields = {
+                "subject_id": subject_id,
+                "identifier": identifier,
+                "display_name": display_name,
+                "cohort": cohort,
+                "sex": _to_str(getattr(subject, "sex", "")),
+                "tags": " ".join(_to_str(tag) for tag in subject_tags),
+                "customer_id": customer_id,
+            }
+            matched, score, matched_fields = _match_terms(parsed_query.terms, fields)
+            if not matched:
+                continue
+
+            subtitle_parts = [identifier or subject_id]
+            if cohort:
+                subtitle_parts.append(f"cohort:{cohort}")
+
+            hit = _build_hit(
+                hit_id=subject_id,
+                hit_type="subject",
+                title=display_name or identifier or subject_id,
+                subtitle=" • ".join(part for part in subtitle_parts if part),
+                url=f"/portal/biospecimen/subjects?subject_id={quote_plus(subject_id)}",
+                customer_id=customer_id,
+                badges=[_to_str(getattr(subject, "sex", "")), cohort],
+                score=score,
+                matched_fields=matched_fields,
+                created_at=_to_str(getattr(subject, "created_at", "")),
+            )
+            hits.append(hit)
+
+    return hits, warnings, {"candidates": candidates, "matched": len(hits)}
+
+
+def _search_biosamples(
+    *,
+    parsed_query: ParsedQuery,
+    extracted_filters: Dict[str, Any],
+    customer_ids: Sequence[str],
+    customer_email_map: Dict[str, str],
+    deps: Dict[str, Any],
+    candidate_cap: int,
+) -> Tuple[List[Dict[str, Any]], List[str], Dict[str, int]]:
+    warnings: List[str] = []
+    hits: List[Dict[str, Any]] = []
+    candidates = 0
+
+    registry = deps.get("biospecimen_registry")
+    if registry is None:
+        warnings.append("Biospecimen registry unavailable")
+        return [], warnings, {"candidates": 0, "matched": 0}
+
+    customer_filter = _to_lower(extracted_filters.get("customer"))
+    required_tags = extracted_filters.get("tags", [])
+    sample_type_filter = _to_lower(extracted_filters.get("sample_type"))
+
+    for customer_id in customer_ids:
+        if not _matches_customer_filter(customer_id, customer_email_map.get(customer_id, ""), customer_filter):
+            continue
+
+        try:
+            biosamples = registry.list_biosamples(customer_id, limit=candidate_cap)
+        except Exception as exc:  # pragma: no cover - defensive
+            warnings.append(f"Failed to query biosamples for customer '{customer_id}'")
+            LOGGER.warning("Biosample search failed for customer %s: %s", customer_id, exc)
+            continue
+
+        if len(biosamples) >= candidate_cap:
+            warnings.append(f"Biosample candidate cap reached for customer '{customer_id}'")
+
+        for biosample in biosamples:
+            candidates += 1
+            biosample_tags = list(getattr(biosample, "tags", []) or [])
+            if not _all_tags_present(biosample_tags, required_tags):
+                continue
+
+            sample_type = _to_lower(getattr(biosample, "sample_type", ""))
+            if sample_type_filter and sample_type != sample_type_filter:
+                continue
+
+            biosample_id = _to_str(getattr(biosample, "biosample_id", ""))
+            subject_id = _to_str(getattr(biosample, "subject_id", ""))
+
+            fields = {
+                "biosample_id": biosample_id,
+                "subject_id": subject_id,
+                "sample_type": sample_type,
+                "tissue_type": _to_str(getattr(biosample, "tissue_type", "")),
+                "tags": " ".join(_to_str(tag) for tag in biosample_tags),
+                "customer_id": customer_id,
+            }
+            matched, score, matched_fields = _match_terms(parsed_query.terms, fields)
+            if not matched:
+                continue
+
+            subtitle_parts = [subject_id] if subject_id else []
+            if sample_type:
+                subtitle_parts.append(sample_type)
+
+            if subject_id:
+                target_url = f"/portal/biospecimen/subjects?subject_id={quote_plus(subject_id)}"
+            else:
+                target_url = f"/portal/biospecimen/subjects?q={quote_plus(biosample_id)}"
+
+            hit = _build_hit(
+                hit_id=biosample_id,
+                hit_type="biosample",
+                title=biosample_id,
+                subtitle=" • ".join(part for part in subtitle_parts if part),
+                url=target_url,
+                customer_id=customer_id,
+                badges=[sample_type, _to_str(getattr(biosample, "tissue_type", ""))],
+                score=score,
+                matched_fields=matched_fields,
+                created_at=_to_str(getattr(biosample, "created_at", "")),
+            )
+            hits.append(hit)
+
+    return hits, warnings, {"candidates": candidates, "matched": len(hits)}
+
+
+def _search_libraries(
+    *,
+    parsed_query: ParsedQuery,
+    extracted_filters: Dict[str, Any],
+    customer_ids: Sequence[str],
+    customer_email_map: Dict[str, str],
+    deps: Dict[str, Any],
+    candidate_cap: int,
+) -> Tuple[List[Dict[str, Any]], List[str], Dict[str, int]]:
+    warnings: List[str] = []
+    hits: List[Dict[str, Any]] = []
+    candidates = 0
+
+    registry = deps.get("biospecimen_registry")
+    if registry is None:
+        warnings.append("Biospecimen registry unavailable")
+        return [], warnings, {"candidates": 0, "matched": 0}
+
+    customer_filter = _to_lower(extracted_filters.get("customer"))
+    required_tags = extracted_filters.get("tags", [])
+
+    for customer_id in customer_ids:
+        if not _matches_customer_filter(customer_id, customer_email_map.get(customer_id, ""), customer_filter):
+            continue
+
+        try:
+            libraries = registry.list_libraries(customer_id, limit=candidate_cap)
+        except Exception as exc:  # pragma: no cover - defensive
+            warnings.append(f"Failed to query libraries for customer '{customer_id}'")
+            LOGGER.warning("Library search failed for customer %s: %s", customer_id, exc)
+            continue
+
+        if len(libraries) >= candidate_cap:
+            warnings.append(f"Library candidate cap reached for customer '{customer_id}'")
+
+        for library in libraries:
+            candidates += 1
+            library_tags = list(getattr(library, "tags", []) or [])
+            if not _all_tags_present(library_tags, required_tags):
+                continue
+
+            library_id = _to_str(getattr(library, "library_id", ""))
+            biosample_id = _to_str(getattr(library, "biosample_id", ""))
+            library_prep = _to_str(getattr(library, "library_prep", ""))
+
+            fields = {
+                "library_id": library_id,
+                "biosample_id": biosample_id,
+                "library_prep": library_prep,
+                "library_kit": _to_str(getattr(library, "library_kit", "")),
+                "protocol_id": _to_str(getattr(library, "protocol_id", "")),
+                "tags": " ".join(_to_str(tag) for tag in library_tags),
+                "customer_id": customer_id,
+            }
+            matched, score, matched_fields = _match_terms(parsed_query.terms, fields)
+            if not matched:
+                continue
+
+            hit = _build_hit(
+                hit_id=library_id,
+                hit_type="library",
+                title=library_id,
+                subtitle=" • ".join(part for part in [biosample_id, library_prep] if part),
+                url=f"/portal/biospecimen/subjects?q={quote_plus(library_id or biosample_id)}",
+                customer_id=customer_id,
+                badges=[library_prep],
+                score=score,
+                matched_fields=matched_fields,
+                created_at=_to_str(getattr(library, "created_at", "")),
+            )
+            hits.append(hit)
+
+    return hits, warnings, {"candidates": candidates, "matched": len(hits)}
+
+
+def _search_manifests(
+    *,
+    parsed_query: ParsedQuery,
+    extracted_filters: Dict[str, Any],
+    customer_ids: Sequence[str],
+    customer_email_map: Dict[str, str],
+    deps: Dict[str, Any],
+    candidate_cap: int,
+) -> Tuple[List[Dict[str, Any]], List[str], Dict[str, int]]:
+    warnings: List[str] = []
+    hits: List[Dict[str, Any]] = []
+    candidates = 0
+
+    manifest_registry = deps.get("manifest_registry")
+    if manifest_registry is None:
+        warnings.append("Manifest registry unavailable")
+        return [], warnings, {"candidates": 0, "matched": 0}
+
+    customer_filter = _to_lower(extracted_filters.get("customer"))
+
+    for customer_id in customer_ids:
+        if not _matches_customer_filter(customer_id, customer_email_map.get(customer_id, ""), customer_filter):
+            continue
+
+        try:
+            manifests = manifest_registry.list_customer_manifests(customer_id, limit=candidate_cap)
+        except Exception as exc:  # pragma: no cover - defensive
+            warnings.append(f"Failed to query manifests for customer '{customer_id}'")
+            LOGGER.warning("Manifest search failed for customer %s: %s", customer_id, exc)
+            continue
+
+        if len(manifests) >= candidate_cap:
+            warnings.append(f"Manifest candidate cap reached for customer '{customer_id}'")
+
+        for manifest in manifests:
+            candidates += 1
+            manifest_id = _to_str(manifest.get("manifest_id"))
+            name = _to_str(manifest.get("name"))
+            description = _to_str(manifest.get("description"))
+            sample_count = _to_str(manifest.get("sample_count"))
+
+            fields = {
+                "manifest_id": manifest_id,
+                "name": name,
+                "description": description,
+                "sample_count": sample_count,
+                "customer_id": customer_id,
+            }
+            matched, score, matched_fields = _match_terms(parsed_query.terms, fields)
+            if not matched:
+                continue
+
+            subtitle_parts = []
+            if description:
+                subtitle_parts.append(description)
+            if sample_count:
+                subtitle_parts.append(f"samples:{sample_count}")
+
+            hit = _build_hit(
+                hit_id=manifest_id,
+                hit_type="manifest",
+                title=name or manifest_id,
+                subtitle=" • ".join(subtitle_parts) or manifest_id,
+                url=f"/portal/manifest-generator?manifest_id={quote_plus(manifest_id)}",
+                customer_id=customer_id,
+                badges=[f"samples:{sample_count}" if sample_count else ""],
+                score=score,
+                matched_fields=matched_fields,
+                created_at=_to_str(manifest.get("created_at")),
+            )
+            hits.append(hit)
+
+    return hits, warnings, {"candidates": candidates, "matched": len(hits)}
+
+
+def _search_users(
+    *,
+    parsed_query: ParsedQuery,
+    extracted_filters: Dict[str, Any],
+    scope: SearchScope,
+    customer_ids: Sequence[str],
+    deps: Dict[str, Any],
+) -> Tuple[List[Dict[str, Any]], List[str], Dict[str, int]]:
+    warnings: List[str] = []
+    hits: List[Dict[str, Any]] = []
+    candidates = 0
+
+    if not scope.is_admin:
+        return [], warnings, {"candidates": 0, "matched": 0}
+
+    customer_manager = deps.get("customer_manager")
+    if customer_manager is None:
+        warnings.append("Customer manager unavailable for user search")
+        return [], warnings, {"candidates": 0, "matched": 0}
+
+    customer_filter = _to_lower(extracted_filters.get("customer"))
+    if not customer_ids:
+        return [], warnings, {"candidates": 0, "matched": 0}
+    allowed_customer_ids = set(customer_ids)
+
+    try:
+        customers = customer_manager.list_customers()
+    except Exception as exc:  # pragma: no cover - defensive
+        warnings.append("Failed to list customers for user search")
+        LOGGER.warning("User search failed while listing customers: %s", exc)
+        return [], warnings, {"candidates": 0, "matched": 0}
+
+    for customer in customers:
+        candidates += 1
+        customer_id = _to_str(getattr(customer, "customer_id", ""))
+        customer_name = _to_str(getattr(customer, "customer_name", ""))
+        email = _to_str(getattr(customer, "email", ""))
+
+        if allowed_customer_ids and customer_id not in allowed_customer_ids:
+            continue
+
+        if customer_filter and customer_filter not in customer_id.lower() and customer_filter not in email.lower() and customer_filter not in customer_name.lower():
+            continue
+
+        fields = {
+            "customer_id": customer_id,
+            "customer_name": customer_name,
+            "email": email,
+            "cost_center": _to_str(getattr(customer, "cost_center", "")),
+            "s3_bucket": _to_str(getattr(customer, "s3_bucket", "")),
+        }
+        matched, score, matched_fields = _match_terms(parsed_query.terms, fields)
+        if not matched:
+            continue
+
+        title = email or customer_name or customer_id
+        subtitle_parts = [customer_id]
+        if customer_name:
+            subtitle_parts.append(customer_name)
+
+        hit = _build_hit(
+            hit_id=customer_id,
+            hit_type="user",
+            title=title,
+            subtitle=" • ".join(subtitle_parts),
+            url=f"/portal/admin/users?q={quote_plus(email or customer_id)}",
+            customer_id=customer_id,
+            badges=["admin" if bool(getattr(customer, "is_admin", False)) else "user"],
+            score=score,
+            matched_fields=matched_fields,
+            created_at="",
+        )
+        hits.append(hit)
+
+    return hits, warnings, {"candidates": candidates, "matched": len(hits)}
+
+
+def _search_clusters(
+    *,
+    parsed_query: ParsedQuery,
+    extracted_filters: Dict[str, Any],
+    deps: Dict[str, Any],
+) -> Tuple[List[Dict[str, Any]], List[str], Dict[str, int]]:
+    warnings: List[str] = []
+    hits: List[Dict[str, Any]] = []
+    candidates = 0
+
+    settings = deps.get("settings")
+    if settings is None:
+        warnings.append("Settings unavailable for cluster search")
+        return [], warnings, {"candidates": 0, "matched": 0}
+
+    region_filter = _to_lower(extracted_filters.get("region"))
+
+    try:
+        from daylib.cluster_service import get_cluster_service
+        from daylib.ursa_config import get_ursa_config
+
+        ursa_config = get_ursa_config()
+        if ursa_config.is_configured:
+            allowed_regions = ursa_config.get_allowed_regions()
+            aws_profile = ursa_config.aws_profile or settings.aws_profile
+        else:
+            allowed_regions = settings.get_allowed_regions()
+            aws_profile = settings.aws_profile
+
+        if not allowed_regions:
+            return [], warnings, {"candidates": 0, "matched": 0}
+
+        service = get_cluster_service(
+            regions=allowed_regions,
+            aws_profile=aws_profile,
+            cache_ttl_seconds=300,
+        )
+        clusters = service.get_all_clusters_with_status(fetch_ssh_status=False)
+    except Exception as exc:  # pragma: no cover - defensive
+        warnings.append("Failed to query cluster status")
+        LOGGER.warning("Cluster search failed: %s", exc)
+        return [], warnings, {"candidates": 0, "matched": 0}
+
+    for cluster_obj in clusters:
+        try:
+            cluster = cluster_obj.to_dict(include_sensitive=False)
+        except Exception:
+            # Fallback for unexpected cluster object shapes
+            cluster = _to_str(cluster_obj)
+        if not isinstance(cluster, dict):
+            continue
+
+        candidates += 1
+        region = _to_lower(cluster.get("region"))
+        if region_filter and region != region_filter:
+            continue
+
+        cluster_name = _to_str(cluster.get("cluster_name"))
+        cluster_status = _to_str(cluster.get("cluster_status"))
+        fleet_status = _to_str(cluster.get("compute_fleet_status"))
+
+        fields = {
+            "cluster_name": cluster_name,
+            "region": region,
+            "cluster_status": cluster_status,
+            "fleet_status": fleet_status,
+        }
+        matched, score, matched_fields = _match_terms(parsed_query.terms, fields)
+        if not matched:
+            continue
+
+        hit = _build_hit(
+            hit_id=f"{cluster_name}:{region}",
+            hit_type="cluster",
+            title=cluster_name,
+            subtitle=" • ".join(part for part in [region, cluster_status, fleet_status] if part),
+            url="/portal/clusters",
+            customer_id="",
+            badges=[region, cluster_status],
+            score=score,
+            matched_fields=matched_fields,
+            created_at="",
+        )
+        hits.append(hit)
+
+    return hits, warnings, {"candidates": candidates, "matched": len(hits)}
+
+
+def _search_monitor_logs(
+    *,
+    parsed_query: ParsedQuery,
+    scope: SearchScope,
+) -> Tuple[List[Dict[str, Any]], List[str], Dict[str, int]]:
+    warnings: List[str] = []
+    hits: List[Dict[str, Any]] = []
+    candidates = 0
+
+    if not scope.is_admin:
+        return [], warnings, {"candidates": 0, "matched": 0}
+
+    # Log search requires terms; otherwise returning logs would be noisy.
+    if not parsed_query.terms:
+        return [], warnings, {"candidates": 0, "matched": 0}
+
+    log_dir = Path.home() / ".ursa" / "logs"
+    log_files = sorted(log_dir.glob("monitor_*.log"), reverse=True) if log_dir.exists() else []
+    if not log_files:
+        return [], warnings, {"candidates": 0, "matched": 0}
+
+    latest_log = log_files[0]
+    try:
+        lines = latest_log.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as exc:  # pragma: no cover - defensive
+        warnings.append("Failed to read monitor log file")
+        LOGGER.warning("Monitor log search failed: %s", exc)
+        return [], warnings, {"candidates": 0, "matched": 0}
+
+    if len(lines) > MAX_MONITOR_LINES:
+        lines = lines[-MAX_MONITOR_LINES:]
+        warnings.append(f"Monitor log search limited to last {MAX_MONITOR_LINES} lines")
+
+    for idx, line in enumerate(lines, start=1):
+        candidates += 1
+        fields = {"line": line, "log_file": latest_log.name}
+        matched, score, matched_fields = _match_terms(parsed_query.terms, fields)
+        if not matched:
+            continue
+
+        snippet = line.strip()
+        if len(snippet) > 220:
+            snippet = snippet[:217] + "..."
+
+        hit = _build_hit(
+            hit_id=f"{latest_log.name}:{idx}",
+            hit_type="monitor_log",
+            title=snippet,
+            subtitle=f"{latest_log.name} • line {idx}",
+            url="/portal/monitor",
+            customer_id="",
+            badges=["monitor"],
+            score=score,
+            matched_fields=matched_fields,
+            created_at="",
+        )
+        hits.append(hit)
+
+    return hits, warnings, {"candidates": candidates, "matched": len(hits)}
+
+
+def search_portal(
+    *,
+    query: str,
+    filters: Dict[str, Any],
+    session_context: Dict[str, Any],
+    deps: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Search across portal entities using federated source queries.
+
+    Args:
+        query: Raw query text from user input.
+        filters: Structured filters from request params.
+        session_context: Session-derived auth context.
+        deps: Service dependencies (state_db, registries, settings, etc.).
+
+    Returns:
+        Normalized search payload with grouped hits and metadata.
+    """
+    started_at = time.perf_counter()
+    warnings: List[str] = []
+
+    parsed_query = _parse_query(query)
+    extracted_filters = _extract_filters(filters, parsed_query)
+    scope = _resolve_scope(filters, session_context, warnings)
+
+    try:
+        limit_per_type = int(filters.get("limit_per_type") or DEFAULT_LIMIT_PER_TYPE)
+    except (TypeError, ValueError):
+        limit_per_type = DEFAULT_LIMIT_PER_TYPE
+        warnings.append("Invalid limit_per_type provided; using default value")
+    if limit_per_type < 1:
+        limit_per_type = DEFAULT_LIMIT_PER_TYPE
+    if limit_per_type > MAX_LIMIT_PER_TYPE:
+        limit_per_type = MAX_LIMIT_PER_TYPE
+        warnings.append(f"limit_per_type capped at {MAX_LIMIT_PER_TYPE}")
+
+    requested_types = _resolve_requested_types(extracted_filters, scope, warnings)
+    customer_ids, customer_email_map = _prepare_customer_targets(
+        scope=scope,
+        extracted_filters=extracted_filters,
+        customer_manager=deps.get("customer_manager"),
+        warnings=warnings,
+    )
+
+    has_structured_filter = any(
+        [
+            extracted_filters.get("state"),
+            extracted_filters.get("region"),
+            extracted_filters.get("customer"),
+            extracted_filters.get("tags"),
+            extracted_filters.get("file_format"),
+            extracted_filters.get("sample_type"),
+            extracted_filters.get("platform"),
+            extracted_filters.get("types"),
+        ]
+    )
+
+    if not parsed_query.terms and not has_structured_filter:
+        return {
+            "query": query,
+            "free_text": parsed_query.free_text,
+            "operators": parsed_query.operators,
+            "scope": scope.requested_scope,
+            "limit_per_type": limit_per_type,
+            "filters": extracted_filters,
+            "types": sorted(requested_types),
+            "results": {t: [] for t in sorted(requested_types)},
+            "counts": {t: 0 for t in sorted(requested_types)},
+            "returned_counts": {t: 0 for t in sorted(requested_types)},
+            "total": 0,
+            "warnings": warnings,
+            "timings_ms": {},
+        }
+
+    candidate_cap = min(MAX_CANDIDATES_PER_TYPE, max(100, limit_per_type * 12))
+
+    results: Dict[str, List[Dict[str, Any]]] = {t: [] for t in sorted(requested_types)}
+    counts: Dict[str, int] = {t: 0 for t in sorted(requested_types)}
+    returned_counts: Dict[str, int] = {t: 0 for t in sorted(requested_types)}
+    timings_ms: Dict[str, float] = {}
+    adapter_stats: Dict[str, Dict[str, int]] = {}
+
+    def _run_adapter(name: str, func: Any, **kwargs: Any) -> None:
+        if name not in requested_types:
+            return
+        start = time.perf_counter()
+        try:
+            hits, adapter_warnings, stats = func(**kwargs)
+        except Exception as exc:  # pragma: no cover - defensive
+            LOGGER.exception("Search adapter '%s' failed", name)
+            hits, adapter_warnings, stats = [], [f"Adapter '{name}' failed: {exc}"], {"candidates": 0, "matched": 0}
+        elapsed_ms = (time.perf_counter() - start) * 1000.0
+        timings_ms[name] = round(elapsed_ms, 2)
+        adapter_stats[name] = {
+            "candidates": int(stats.get("candidates", 0)),
+            "matched": int(stats.get("matched", 0)),
+        }
+
+        warnings.extend(adapter_warnings)
+
+        counts[name] = len(hits)
+        limited_hits, truncated = _sort_and_limit_hits(hits, limit_per_type)
+        if truncated:
+            warnings.append(f"Results for '{name}' truncated to {limit_per_type} entries")
+        results[name] = limited_hits
+        returned_counts[name] = len(limited_hits)
+
+    _run_adapter(
+        "workset",
+        _search_worksets,
+        parsed_query=parsed_query,
+        extracted_filters=extracted_filters,
+        scope=scope,
+        customer_ids=customer_ids,
+        customer_email_map=customer_email_map,
+        deps=deps,
+        candidate_cap=candidate_cap,
+    )
+
+    _run_adapter(
+        "file",
+        _search_files,
+        parsed_query=parsed_query,
+        extracted_filters=extracted_filters,
+        customer_ids=customer_ids,
+        customer_email_map=customer_email_map,
+        deps=deps,
+        candidate_cap=candidate_cap,
+    )
+
+    _run_adapter(
+        "subject",
+        _search_subjects,
+        parsed_query=parsed_query,
+        extracted_filters=extracted_filters,
+        customer_ids=customer_ids,
+        customer_email_map=customer_email_map,
+        deps=deps,
+        candidate_cap=candidate_cap,
+    )
+
+    _run_adapter(
+        "biosample",
+        _search_biosamples,
+        parsed_query=parsed_query,
+        extracted_filters=extracted_filters,
+        customer_ids=customer_ids,
+        customer_email_map=customer_email_map,
+        deps=deps,
+        candidate_cap=candidate_cap,
+    )
+
+    _run_adapter(
+        "library",
+        _search_libraries,
+        parsed_query=parsed_query,
+        extracted_filters=extracted_filters,
+        customer_ids=customer_ids,
+        customer_email_map=customer_email_map,
+        deps=deps,
+        candidate_cap=candidate_cap,
+    )
+
+    _run_adapter(
+        "manifest",
+        _search_manifests,
+        parsed_query=parsed_query,
+        extracted_filters=extracted_filters,
+        customer_ids=customer_ids,
+        customer_email_map=customer_email_map,
+        deps=deps,
+        candidate_cap=candidate_cap,
+    )
+
+    _run_adapter(
+        "cluster",
+        _search_clusters,
+        parsed_query=parsed_query,
+        extracted_filters=extracted_filters,
+        deps=deps,
+    )
+
+    _run_adapter(
+        "user",
+        _search_users,
+        parsed_query=parsed_query,
+        extracted_filters=extracted_filters,
+        scope=scope,
+        customer_ids=customer_ids,
+        deps=deps,
+    )
+
+    _run_adapter(
+        "monitor_log",
+        _search_monitor_logs,
+        parsed_query=parsed_query,
+        scope=scope,
+    )
+
+    total = sum(returned_counts.values())
+    total_ms = round((time.perf_counter() - started_at) * 1000.0, 2)
+    timings_ms["total"] = total_ms
+
+    LOGGER.info(
+        "portal_search: scope=%s terms=%s types=%s total=%d duration_ms=%.2f adapters=%s",
+        scope.requested_scope,
+        parsed_query.terms,
+        sorted(requested_types),
+        total,
+        total_ms,
+        adapter_stats,
+    )
+
+    return {
+        "query": query,
+        "free_text": parsed_query.free_text,
+        "operators": parsed_query.operators,
+        "scope": scope.requested_scope,
+        "limit_per_type": limit_per_type,
+        "filters": extracted_filters,
+        "types": sorted(requested_types),
+        "results": results,
+        "counts": counts,
+        "returned_counts": returned_counts,
+        "total": total,
+        "warnings": warnings,
+        "timings_ms": timings_ms,
+        "adapter_stats": adapter_stats,
+    }

--- a/daylib/workset_api.py
+++ b/daylib/workset_api.py
@@ -627,6 +627,7 @@ def create_app(
             file_registry=file_registry,
             linked_bucket_manager=linked_bucket_manager,
             biospecimen_registry=biospecimen_registry_for_portal,
+            manifest_registry=manifest_registry,
         )
         portal_router = create_portal_router(portal_deps)
         app.include_router(portal_router)

--- a/daylib/workset_customer.py
+++ b/daylib/workset_customer.py
@@ -10,7 +10,7 @@ import logging
 import secrets
 import datetime as dt
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 import boto3
 from botocore.exceptions import ClientError
@@ -61,6 +61,7 @@ class CustomerManager:
             session_kwargs["profile_name"] = profile
 
         session = boto3.Session(**session_kwargs)
+        self._session = session
         self.s3 = session.client("s3")
         self.dynamodb = session.resource("dynamodb")
         self.region = region
@@ -69,6 +70,7 @@ class CustomerManager:
         # Customer table for tracking
         self.customer_table_name = "daylily-customers"
         self.customer_table = self.dynamodb.Table(self.customer_table_name)
+        self._regional_s3_clients: Dict[str, Any] = {}
 
         # Sanity logging/guards so mis-bound DynamoDB resources surface immediately
         LOGGER.info(
@@ -208,19 +210,20 @@ class CustomerManager:
         """
         # Use provided region or default to CustomerManager's region
         target_region = bucket_region or self.region
+        s3_client = self._get_s3_client_for_region(target_region)
 
         try:
             # Create bucket - us-east-1 has special handling (no LocationConstraint)
             if target_region == "us-east-1":
-                self.s3.create_bucket(Bucket=bucket_name)
+                s3_client.create_bucket(Bucket=bucket_name)
             else:
-                self.s3.create_bucket(
+                s3_client.create_bucket(
                     Bucket=bucket_name,
                     CreateBucketConfiguration={"LocationConstraint": target_region},
                 )
 
             # Enable versioning
-            self.s3.put_bucket_versioning(
+            s3_client.put_bucket_versioning(
                 Bucket=bucket_name,
                 VersioningConfiguration={"Status": "Enabled"},
             )
@@ -235,7 +238,7 @@ class CustomerManager:
             if cost_center:
                 tags.append({"Key": "CostCenter", "Value": cost_center})
 
-            self.s3.put_bucket_tagging(
+            s3_client.put_bucket_tagging(
                 Bucket=bucket_name,
                 Tagging={"TagSet": tags},
             )
@@ -261,7 +264,7 @@ class CustomerManager:
                 ]
             }
 
-            self.s3.put_bucket_lifecycle_configuration(
+            s3_client.put_bucket_lifecycle_configuration(
                 Bucket=bucket_name,
                 LifecycleConfiguration=lifecycle_policy,
             )
@@ -274,6 +277,14 @@ class CustomerManager:
             else:
                 LOGGER.error("Failed to create bucket %s: %s", bucket_name, str(e))
                 raise
+
+    def _get_s3_client_for_region(self, region: str):
+        """Return an S3 client scoped to the requested region."""
+        if region == self.region:
+            return self.s3
+        if region not in self._regional_s3_clients:
+            self._regional_s3_clients[region] = self._session.client("s3", region_name=region)
+        return self._regional_s3_clients[region]
 
     def _save_customer_config(self, config: CustomerConfig) -> None:
         """Save customer configuration to DynamoDB.

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -127,6 +127,17 @@ p { margin-bottom: var(--spacing-md); }
 .text-warning { color: var(--color-warning); }
 .text-error { color: var(--color-error); }
 
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    border: 0;
+}
+
 /* Container */
 .container {
     width: 100%;
@@ -203,6 +214,40 @@ p { margin-bottom: var(--spacing-md); }
     display: flex;
     align-items: center;
     gap: var(--spacing-md);
+}
+
+.global-search-form {
+    display: flex;
+    align-items: center;
+    background: rgba(255, 255, 255, 0.14);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: var(--radius-md);
+    min-width: 320px;
+}
+
+.global-search-input {
+    border: none;
+    background: transparent;
+    color: var(--color-white);
+    padding: 0.5rem 0.65rem;
+    min-width: 240px;
+}
+
+.global-search-input::placeholder {
+    color: rgba(255, 255, 255, 0.75);
+}
+
+.global-search-input:focus {
+    outline: none;
+}
+
+.global-search-submit {
+    border: none;
+    background: transparent;
+    color: var(--color-white);
+    padding: 0.5rem 0.65rem;
+    cursor: pointer;
+    border-left: 1px solid rgba(255, 255, 255, 0.25);
 }
 
 .user-menu {
@@ -291,6 +336,18 @@ p { margin-bottom: var(--spacing-md); }
 
 @media (max-width: 768px) {
     .menu-toggle { display: block; }
+    .nav {
+        gap: var(--spacing-md);
+    }
+    .global-search-form {
+        min-width: 170px;
+        max-width: 220px;
+    }
+    .global-search-input {
+        min-width: 0;
+        width: 100%;
+        font-size: 0.85rem;
+    }
     .nav-links {
         display: none;
         position: absolute;
@@ -676,6 +733,17 @@ p { margin-bottom: var(--spacing-md); }
     line-height: 1;
     border-radius: var(--radius-full);
     text-transform: uppercase;
+}
+
+.badge-outline {
+    background: transparent;
+    border: 1px solid var(--color-gray-300);
+    color: var(--color-gray-700);
+}
+
+.badge-info {
+    background: rgba(15, 118, 110, 0.14);
+    color: #0f766e;
 }
 
 /* Workset State Badges - Bold & Classy */
@@ -1611,3 +1679,134 @@ p { margin-bottom: var(--spacing-md); }
     margin-bottom: var(--spacing-xs);
 }
 
+/* Global Search */
+.search-query-card {
+    margin-bottom: var(--spacing-lg);
+}
+
+.search-query-row {
+    display: flex;
+    gap: var(--spacing-sm);
+    align-items: center;
+}
+
+.search-query-input {
+    flex: 1;
+}
+
+.search-scope-select {
+    min-width: 180px;
+}
+
+.search-operators-hint {
+    margin-top: var(--spacing-sm);
+    color: var(--color-gray-600);
+    font-size: 0.85rem;
+}
+
+.search-layout {
+    display: grid;
+    grid-template-columns: 300px minmax(0, 1fr);
+    gap: var(--spacing-lg);
+    align-items: start;
+}
+
+.search-facets {
+    position: sticky;
+    top: 90px;
+}
+
+.search-type-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+}
+
+.search-type-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-sm);
+    color: var(--color-gray-700);
+    font-size: 0.9rem;
+}
+
+.search-results-summary {
+    margin-bottom: var(--spacing-md);
+    color: var(--color-gray-700);
+}
+
+.search-group-card {
+    margin-bottom: var(--spacing-md);
+}
+
+.search-group-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--spacing-sm);
+}
+
+.search-hit-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+}
+
+.search-hit-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--spacing-md);
+    padding: var(--spacing-md);
+    border: 1px solid var(--color-gray-200);
+    border-radius: var(--radius-md);
+    color: inherit;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.search-hit-item:hover {
+    border-color: var(--color-accent);
+    box-shadow: var(--shadow-sm);
+}
+
+.search-hit-title {
+    font-weight: 600;
+    color: var(--color-primary);
+}
+
+.search-hit-subtitle {
+    font-size: 0.875rem;
+    color: var(--color-gray-600);
+    margin-top: 2px;
+}
+
+.search-hit-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 6px;
+}
+
+.search-warnings-list {
+    margin: 0.35rem 0 0;
+    padding-left: 1rem;
+}
+
+@media (max-width: 1024px) {
+    .search-layout {
+        grid-template-columns: 1fr;
+    }
+    .search-facets {
+        position: static;
+    }
+}
+
+@media (max-width: 768px) {
+    .search-query-row {
+        flex-wrap: wrap;
+    }
+    .search-scope-select {
+        min-width: 140px;
+    }
+}

--- a/static/js/global-search.js
+++ b/static/js/global-search.js
@@ -1,0 +1,97 @@
+(function () {
+    'use strict';
+
+    var STORAGE_KEY = 'ursa.global_search.query';
+
+    function isTypingElement(element) {
+        if (!element) {
+            return false;
+        }
+        var tag = (element.tagName || '').toUpperCase();
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+            return true;
+        }
+        return Boolean(element.isContentEditable);
+    }
+
+    function syncFacetHidden(facetsForm, fieldName, fieldValue) {
+        if (!facetsForm) {
+            return;
+        }
+        var hidden = facetsForm.querySelector('input[name="' + fieldName + '"]');
+        if (hidden) {
+            hidden.value = fieldValue;
+        }
+    }
+
+    function initGlobalSearch() {
+        var headerInput = document.getElementById('global-search-input');
+        var queryForms = document.querySelectorAll('[data-global-search-form]');
+        var facetsForm = document.getElementById('portal-search-facets');
+        var pageSearchForm = document.getElementById('portal-search-form');
+
+        queryForms.forEach(function (form) {
+            form.addEventListener('submit', function () {
+                var input = form.querySelector('input[name="q"]');
+                if (!input) {
+                    return;
+                }
+                var value = (input.value || '').trim();
+                if (value) {
+                    sessionStorage.setItem(STORAGE_KEY, value);
+                } else {
+                    sessionStorage.removeItem(STORAGE_KEY);
+                }
+            });
+        });
+
+        if (headerInput && !headerInput.value.trim()) {
+            var saved = sessionStorage.getItem(STORAGE_KEY) || '';
+            if (saved) {
+                headerInput.value = saved;
+            }
+        }
+
+        document.addEventListener('keydown', function (event) {
+            if (event.defaultPrevented || event.key !== '/') {
+                return;
+            }
+            if (event.ctrlKey || event.metaKey || event.altKey) {
+                return;
+            }
+            if (isTypingElement(document.activeElement)) {
+                return;
+            }
+            if (!headerInput) {
+                return;
+            }
+            event.preventDefault();
+            headerInput.focus();
+            headerInput.select();
+        });
+
+        if (pageSearchForm && facetsForm) {
+            var queryInput = pageSearchForm.querySelector('input[name="q"]');
+            if (queryInput) {
+                queryInput.addEventListener('input', function () {
+                    syncFacetHidden(facetsForm, 'q', queryInput.value || '');
+                });
+            }
+
+            var scopeSelect = pageSearchForm.querySelector('select[name="scope"]');
+            if (scopeSelect) {
+                scopeSelect.addEventListener('change', function () {
+                    syncFacetHidden(facetsForm, 'scope', scopeSelect.value || 'mine');
+                });
+            }
+
+            facetsForm.querySelectorAll('[data-submit-on-change]').forEach(function (element) {
+                element.addEventListener('change', function () {
+                    facetsForm.submit();
+                });
+            });
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', initGlobalSearch);
+})();

--- a/static/js/manifest-generator.js
+++ b/static/js/manifest-generator.js
@@ -51,12 +51,13 @@ let currentBrowserPrefix = '';
 let bucketsLoaded = false;
 
 // Initialize on load
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
     addAnalysisInput(); // Start with one empty input
     updateManifestPreview();
 
     // Load saved manifests list for this customer (if in portal context)
-    refreshSavedManifests?.();
+    await refreshSavedManifests?.();
+    await loadManifestFromQueryParam();
 });
 
 function getCustomerId() {
@@ -97,6 +98,31 @@ async function refreshSavedManifests() {
         console.error('Failed to refresh saved manifests:', err);
         // Non-fatal; portal may not have manifest storage configured
     }
+}
+
+function getManifestIdFromQueryParam() {
+    const params = new URLSearchParams(window.location.search);
+    return (params.get('manifest_id') || '').trim();
+}
+
+async function loadManifestFromQueryParam() {
+    const manifestId = getManifestIdFromQueryParam();
+    if (!manifestId) {
+        return;
+    }
+
+    const select = document.getElementById('saved-manifest-select');
+    if (!select) {
+        return;
+    }
+
+    select.value = manifestId;
+    if (select.value !== manifestId) {
+        showToast?.('error', 'Manifest not found', `Saved manifest not found: ${manifestId}`);
+        return;
+    }
+
+    await loadSelectedManifest();
 }
 
 /**
@@ -923,4 +949,3 @@ function escapeHtml(str) {
               .replace(/>/g, '&gt;')
               .replace(/"/g, '&quot;');
 }
-

--- a/templates/admin/users.html
+++ b/templates/admin/users.html
@@ -78,6 +78,22 @@
         <div class="card" style="grid-column: 1 / -1;">
             <h3 class="card-title"><i class="fas fa-users"></i> Existing Users</h3>
 
+            <form method="get" action="/portal/admin/users" class="mb-md d-flex gap-sm">
+                <input
+                    type="text"
+                    name="q"
+                    class="form-control"
+                    value="{{ user_query | default('') }}"
+                    placeholder="Filter by email, customer name, or customer ID"
+                >
+                <button type="submit" class="btn btn-outline">
+                    <i class="fas fa-search"></i> Filter
+                </button>
+                {% if user_query %}
+                <a href="/portal/admin/users" class="btn btn-outline">Clear</a>
+                {% endif %}
+            </form>
+
             {% if customers and customers|length > 0 %}
             <table class="job-table" style="width: 100%;">
                 <thead>

--- a/templates/base.html
+++ b/templates/base.html
@@ -65,6 +65,25 @@
                         <li><a href="/portal/monitor" class="nav-link {% if active_page == 'monitor' %}active{% endif %}">Monitor</a></li>
                         <li><a href="/portal/usage" class="nav-link {% if active_page == 'usage' %}active{% endif %}">Usage</a></li>
                     </ul>
+
+                    {% if user_authenticated %}
+                    <form class="global-search-form" method="get" action="/portal/search" data-global-search-form role="search">
+                        <label for="global-search-input" class="sr-only">Global search</label>
+                        <input
+                            id="global-search-input"
+                            type="text"
+                            name="q"
+                            class="global-search-input"
+                            value="{{ search.query if search is defined else '' }}"
+                            placeholder="Search all data (/)"
+                            autocomplete="off"
+                        >
+                        <input type="hidden" name="scope" value="{{ search_scope | default('all' if is_admin else 'mine') }}">
+                        <button type="submit" class="global-search-submit" aria-label="Submit search">
+                            <i class="fas fa-search"></i>
+                        </button>
+                    </form>
+                    {% endif %}
                     
                     <div class="nav-user">
                         {% if auth_enabled %}
@@ -171,8 +190,8 @@
     </script>
     <script src="/static/js/api.js?v={{ cache_bust | default('1') }}"></script>
     <script src="/static/js/main.js?v={{ cache_bust | default('1') }}"></script>
+    <script src="/static/js/global-search.js?v={{ cache_bust | default('1') }}"></script>
     <script src="/static/js/table-utils.js?v={{ cache_bust | default('1') }}"></script>
     {% block extra_js %}{% endblock %}
 </body>
 </html>
-

--- a/templates/biospecimen/subjects.html
+++ b/templates/biospecimen/subjects.html
@@ -54,6 +54,34 @@
         </div>
     </div>
 
+    <!-- Subject Filters -->
+    <div class="card mb-xl" id="subjects-filter-card">
+        <form method="get" action="/portal/biospecimen/subjects" class="d-flex gap-sm flex-wrap">
+            <input
+                type="text"
+                name="q"
+                class="form-control"
+                value="{{ subject_query | default('') }}"
+                placeholder="Search subject ID, name, cohort, sex"
+                style="min-width: 260px; flex: 1;"
+            >
+            <input
+                type="text"
+                name="subject_id"
+                class="form-control"
+                value="{{ subject_id_filter | default('') }}"
+                placeholder="Filter by exact subject identifier"
+                style="min-width: 220px;"
+            >
+            <button type="submit" class="btn btn-outline">
+                <i class="fas fa-search"></i> Filter
+            </button>
+            {% if subject_query or subject_id_filter %}
+            <a href="/portal/biospecimen/subjects" class="btn btn-outline">Clear</a>
+            {% endif %}
+        </form>
+    </div>
+
     <!-- Subjects Table -->
     <div class="card" id="subjects-table-card">
         <h3 class="card-title"><i class="fas fa-users"></i> All Subjects</h3>
@@ -233,4 +261,3 @@ function addBiosample(subjectId) {
 }
 </script>
 {% endblock %}
-

--- a/templates/search/results.html
+++ b/templates/search/results.html
@@ -1,0 +1,169 @@
+{% extends "base.html" %}
+{% set active_page = 'search' %}
+
+{% block title %}Global Search - Ursa Customer Portal{% endblock %}
+
+{% block content %}
+<div class="container search-page">
+    <div class="page-header">
+        <h1 class="page-title">Global Search</h1>
+        <p class="page-subtitle">Search worksets, files, biospecimen entities, manifests, clusters, and admin entities from one place.</p>
+    </div>
+
+    <form id="portal-search-form" class="card search-query-card" method="get" action="/portal/search" data-global-search-form>
+        <div class="search-query-row">
+            <input type="text" name="q" class="form-control search-query-input" value="{{ search.query }}" placeholder="Try: type:file tag:germline or state:in_progress" autocomplete="off">
+            {% if is_admin %}
+            <select name="scope" class="form-control form-select search-scope-select" data-submit-on-change>
+                <option value="all" {% if search.scope == 'all' %}selected{% endif %}>All customers</option>
+                <option value="mine" {% if search.scope == 'mine' %}selected{% endif %}>My customer only</option>
+            </select>
+            {% else %}
+            <input type="hidden" name="scope" value="mine">
+            {% endif %}
+            <button type="submit" class="btn btn-primary">
+                <i class="fas fa-search"></i> Search
+            </button>
+        </div>
+        <div class="search-operators-hint">
+            Operators: <code>type:</code> <code>state:</code> <code>region:</code> <code>customer:</code> <code>tag:</code>
+        </div>
+    </form>
+
+    {% if search.warnings %}
+    <div class="alert alert-warning">
+        <i class="fas fa-exclamation-triangle"></i>
+        <div>
+            <strong>Search warnings</strong>
+            <ul class="search-warnings-list">
+                {% for warning in search.warnings %}
+                <li>{{ warning }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
+    {% endif %}
+
+    <div class="search-layout">
+        <aside>
+            <form id="portal-search-facets" class="card search-facets" method="get" action="/portal/search">
+                <input type="hidden" name="q" value="{{ search.query }}">
+                <input type="hidden" name="scope" value="{{ search.scope }}">
+                <input type="hidden" name="limit_per_type" value="{{ search.limit_per_type }}">
+
+                <h3 class="card-title"><i class="fas fa-filter"></i> Filters</h3>
+
+                <div class="form-group">
+                    <label class="form-label">Types</label>
+                    <div class="search-type-list">
+                        {% for facet in type_facets %}
+                        <label class="search-type-item">
+                            <input type="checkbox" name="type" value="{{ facet.key }}" {% if facet.selected %}checked{% endif %} data-submit-on-change>
+                            <span>{{ facet.label }}</span>
+                            <span class="badge badge-outline">{{ facet.count }}</span>
+                        </label>
+                        {% endfor %}
+                    </div>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label">State</label>
+                    <input type="text" name="state" class="form-control" value="{{ search.filters.state | default('') }}" placeholder="in_progress">
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label">Region</label>
+                    <input type="text" name="region" class="form-control" value="{{ search.filters.region | default('') }}" placeholder="us-east-1">
+                </div>
+
+                {% if is_admin %}
+                <div class="form-group">
+                    <label class="form-label">Customer</label>
+                    <input type="text" name="customer" class="form-control" value="{{ search.filters.customer | default('') }}" placeholder="cust-123 or user@example.com">
+                </div>
+                {% endif %}
+
+                <div class="form-group">
+                    <label class="form-label">Tag</label>
+                    <input type="text" name="tag" class="form-control" value="{{ (search.filters.tags or []) | join(',') }}" placeholder="germline,clinical">
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label">File Format</label>
+                    <input type="text" name="file_format" class="form-control" value="{{ search.filters.file_format | default('') }}" placeholder="fastq">
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label">Sample Type</label>
+                    <input type="text" name="sample_type" class="form-control" value="{{ search.filters.sample_type | default('') }}" placeholder="blood">
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label">Platform</label>
+                    <input type="text" name="platform" class="form-control" value="{{ search.filters.platform | default('') }}" placeholder="NovaSeq">
+                </div>
+
+                <div class="d-flex gap-sm">
+                    <button type="submit" class="btn btn-primary btn-sm">
+                        <i class="fas fa-check"></i> Apply
+                    </button>
+                    <a href="/portal/search?q={{ search.query | urlencode }}&scope={{ search.scope }}" class="btn btn-outline btn-sm">Clear</a>
+                </div>
+            </form>
+        </aside>
+
+        <section>
+            <div class="search-results-summary">
+                <strong>{{ search.total }}</strong> result{% if search.total != 1 %}s{% endif %}
+                {% if search.query %} for <code>{{ search.query }}</code>{% endif %}
+            </div>
+
+            {% if not has_query and not has_filters %}
+            <div class="card empty-state">
+                <div class="empty-state-icon"><i class="fas fa-search"></i></div>
+                <h4 class="empty-state-title">Start searching</h4>
+                <p class="empty-state-text">Enter text or operators to search across all portal entities.</p>
+            </div>
+            {% elif search.total == 0 %}
+            <div class="card empty-state">
+                <div class="empty-state-icon"><i class="fas fa-search-minus"></i></div>
+                <h4 class="empty-state-title">No matching results</h4>
+                <p class="empty-state-text">Try broadening your query or removing filters.</p>
+            </div>
+            {% endif %}
+
+            {% for type_name in search.types %}
+            {% set hits = search.results.get(type_name, []) %}
+            {% if hits %}
+            <div class="card search-group-card" id="search-group-{{ type_name }}">
+                <div class="search-group-header">
+                    <h3 class="card-title">{{ type_labels.get(type_name, type_name | replace('_', ' ') | title) }}</h3>
+                    <span class="badge badge-info">{{ search.returned_counts.get(type_name, 0) }}</span>
+                </div>
+
+                <div class="search-hit-list">
+                    {% for hit in hits %}
+                    <a href="{{ hit.url }}" class="search-hit-item">
+                        <div class="search-hit-main">
+                            <div class="search-hit-title">{{ hit.title }}</div>
+                            <div class="search-hit-subtitle">{{ hit.subtitle }}</div>
+                            <div class="search-hit-badges">
+                                {% if is_admin and search.scope == 'all' and hit.customer_id %}
+                                <span class="badge badge-outline">customer:{{ hit.customer_id }}</span>
+                                {% endif %}
+                                {% for badge in hit.badges %}
+                                <span class="badge badge-outline">{{ badge }}</span>
+                                {% endfor %}
+                            </div>
+                        </div>
+                        <i class="fas fa-arrow-right"></i>
+                    </a>
+                    {% endfor %}
+                </div>
+            </div>
+            {% endif %}
+            {% endfor %}
+        </section>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_manifest_registry.py
+++ b/tests/test_manifest_registry.py
@@ -160,6 +160,67 @@ class TestGetManifestAndTsv:
         assert result is None
 
 
+class TestPkOnlyManifestSchema:
+    """Compatibility tests for environments where manifest table uses pk-only schema."""
+
+    def test_save_list_get_with_pk_only_schema(self, manifest_registry):
+        # Simulate pre-detected pk-only table schema
+        manifest_registry._schema_loaded = True
+        manifest_registry._hash_key_name = "pk"
+        manifest_registry._range_key_name = None
+
+        # Save should include pk key and pk-based condition expression
+        manifest_registry.table.put_item.return_value = {}
+        saved = manifest_registry.save_manifest(
+            customer_id="cust-001",
+            tsv_content="RUN_ID\tSAMPLE_ID\nR0\tHG002\n",
+            name="Compat",
+        )
+        put_kwargs = manifest_registry.table.put_item.call_args.kwargs
+        assert put_kwargs["Item"]["pk"] == f"manifest#cust-001#{saved.manifest_id}"
+        assert put_kwargs["ConditionExpression"] == "attribute_not_exists(pk)"
+
+        # List should use scan fallback and still return normalized metadata
+        manifest_registry.table.scan.return_value = {
+            "Items": [
+                {
+                    "pk": f"manifest#cust-001#{saved.manifest_id}",
+                    "entity_type": "manifest",
+                    "customer_id": "cust-001",
+                    "manifest_id": saved.manifest_id,
+                    "created_at": saved.created_at,
+                    "name": "Compat",
+                    "description": "",
+                    "sample_count": 1,
+                    "tsv_sha256": saved.tsv_sha256,
+                    "tsv_gzip_b64": saved.tsv_gzip_b64,
+                }
+            ]
+        }
+        listed = manifest_registry.list_customer_manifests("cust-001")
+        assert len(listed) == 1
+        assert listed[0]["manifest_id"] == saved.manifest_id
+
+        # Get should use pk key for get_item
+        manifest_registry.table.get_item.return_value = {
+            "Item": {
+                "pk": f"manifest#cust-001#{saved.manifest_id}",
+                "entity_type": "manifest",
+                "customer_id": "cust-001",
+                "manifest_id": saved.manifest_id,
+                "created_at": saved.created_at,
+                "name": "Compat",
+                "description": "",
+                "sample_count": 1,
+                "tsv_sha256": saved.tsv_sha256,
+                "tsv_gzip_b64": saved.tsv_gzip_b64,
+            }
+        }
+        _ = manifest_registry.get_manifest(customer_id="cust-001", manifest_id=saved.manifest_id)
+        get_kwargs = manifest_registry.table.get_item.call_args.kwargs
+        assert get_kwargs["Key"]["pk"] == f"manifest#cust-001#{saved.manifest_id}"
+
+
 class TestCreateTableIfNotExists:
     """Tests for ManifestRegistry.create_table_if_not_exists behavior."""
 

--- a/tests/test_workset_customer.py
+++ b/tests/test_workset_customer.py
@@ -73,6 +73,30 @@ def test_onboard_customer(customer_manager, mock_aws):
     mock_table.put_item.assert_called_once()
 
 
+def test_onboard_customer_us_east_1_uses_east_client_without_location_constraint(customer_manager, mock_aws):
+    """Creating a us-east-1 bucket must use a us-east-1 client and omit LocationConstraint."""
+    session_instance = mock_aws["session"].return_value
+    default_s3 = mock_aws["s3"]
+    east_s3 = MagicMock()
+
+    def _client_side_effect(service_name, **kwargs):
+        if service_name == "s3" and kwargs.get("region_name") == "us-east-1":
+            return east_s3
+        return default_s3
+
+    session_instance.client.side_effect = _client_side_effect
+
+    config = customer_manager.onboard_customer(
+        customer_name="East Region Customer",
+        email="east@example.com",
+        bucket_region="us-east-1",
+    )
+
+    assert config.bucket_region == "us-east-1"
+    east_s3.create_bucket.assert_called_once_with(Bucket=config.s3_bucket)
+    default_s3.create_bucket.assert_not_called()
+
+
 def test_save_customer_config(customer_manager, mock_aws):
     """Test saving customer configuration."""
     mock_table = mock_aws["table"]
@@ -445,4 +469,3 @@ class TestBillingAccountIdIsMetadataOnly:
             "not routed to external billing accounts. If this test fails, the "
             "architecture has changed and this test should be updated."
         )
-

--- a/tests/test_workset_portal.py
+++ b/tests/test_workset_portal.py
@@ -769,6 +769,130 @@ class TestPortalRoutes:
         assert "text/html" in follow.headers["content-type"]
 
 
+class TestPortalGlobalSearch:
+    """Tests for global portal search routes and authz scope behavior."""
+
+    def _make_admin_search_client(self, mock_state_db):
+        mock_customer_manager = MagicMock()
+
+        admin = MagicMock()
+        admin.customer_id = "cust-admin"
+        admin.is_admin = True
+        admin.email = "admin@example.com"
+        admin.customer_name = "Admin Customer"
+
+        other = MagicMock()
+        other.customer_id = "cust-other"
+        other.is_admin = False
+        other.email = "other@example.com"
+        other.customer_name = "Other Customer"
+
+        def _get_customer_by_email(email: str):
+            if email == admin.email:
+                return admin
+            if email == other.email:
+                return other
+            return None
+
+        mock_customer_manager.get_customer_by_email.side_effect = _get_customer_by_email
+        mock_customer_manager.list_customers.return_value = [admin, other]
+
+        app = create_app(
+            state_db=mock_state_db,
+            enable_auth=False,
+            customer_manager=mock_customer_manager,
+        )
+        client = TestClient(app)
+        client.post("/portal/login", data={"email": admin.email, "password": "testpass"})
+        return client
+
+    def test_portal_search_unauthenticated_redirects_to_login(self, mock_state_db):
+        app = create_app(state_db=mock_state_db, enable_auth=False)
+        client = TestClient(app)
+
+        response = client.get("/portal/search", follow_redirects=False)
+        assert response.status_code == 302
+        assert "/portal/login" in response.headers["location"]
+
+    def test_portal_search_header_form_is_rendered_for_authenticated_pages(self, authenticated_client):
+        response = authenticated_client.get("/portal")
+        assert response.status_code == 200
+        assert 'id="global-search-input"' in response.text
+
+    def test_portal_search_page_renders_for_authenticated_user(self, authenticated_client):
+        response = authenticated_client.get("/portal/search?q=example")
+        assert response.status_code == 200
+        assert "Global Search" in response.text
+        assert "id=\"portal-search-facets\"" in response.text
+
+    def test_api_portal_search_non_admin_cannot_query_admin_types(self, mock_state_db):
+        client = _make_authenticated_client(
+            mock_state_db,
+            customer_id="cust-001",
+            is_admin=False,
+            email="user@example.com",
+        )
+
+        response = client.get(
+            "/api/portal/search",
+            params={
+                "q": "type:user",
+                "type": "user",
+                "scope": "all",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["scope"] == "mine"
+        assert "user" not in data["types"]
+        assert "monitor_log" not in data["types"]
+
+    def test_api_portal_search_admin_scope_all_returns_cross_customer_user_hits(self, mock_state_db):
+        client = self._make_admin_search_client(mock_state_db)
+        response = client.get(
+            "/api/portal/search",
+            params={"q": "example.com", "type": "user", "scope": "all"},
+        )
+        assert response.status_code == 200
+
+        payload = response.json()
+        user_hits = payload["results"].get("user", [])
+        hit_customer_ids = {hit["customer_id"] for hit in user_hits}
+        assert "cust-admin" in hit_customer_ids
+        assert "cust-other" in hit_customer_ids
+
+    def test_api_portal_search_admin_scope_mine_excludes_other_customers(self, mock_state_db):
+        client = self._make_admin_search_client(mock_state_db)
+        response = client.get(
+            "/api/portal/search",
+            params={"q": "example.com", "type": "user", "scope": "mine"},
+        )
+        assert response.status_code == 200
+
+        payload = response.json()
+        user_hits = payload["results"].get("user", [])
+        hit_customer_ids = {hit["customer_id"] for hit in user_hits}
+        assert hit_customer_ids == {"cust-admin"}
+
+    def test_api_portal_search_operator_parsing_from_query(self, mock_state_db):
+        client = _make_authenticated_client(
+            mock_state_db,
+            customer_id="cust-001",
+            is_admin=False,
+            email="user@example.com",
+        )
+
+        response = client.get(
+            "/api/portal/search",
+            params={"q": "type:file tag:germline"},
+        )
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["operators"]["type"] == ["file"]
+        assert payload["operators"]["tag"] == ["germline"]
+        assert payload["types"] == ["file"]
+
+
 class TestPortalBucketsEditDialog:
     """Regression tests for per-bucket Edit button + modal on /portal/files/buckets."""
 


### PR DESCRIPTION
## Summary
- add portal global search (federated v1) with HTML and JSON routes
- add search UI (header form, results page, facets, keyboard shortcut)
- add manifest deep-link load via manifest_id query param
- add subject/users optional query filtering support
- fix customer bucket provisioning for us-east-1 by using region-scoped S3 clients
- fix manifest registry to support legacy and pk-based DynamoDB schemas
- add/extend tests for portal search, manifest registry schema compatibility, and us-east-1 bucket create path

## Validation
- pytest -q tests/test_workset_portal.py
- pytest -q tests/test_manifest_registry.py tests/test_manifest_api.py
- pytest -q tests/test_workset_customer.py
- python -m compileall -q daylib/search daylib/routes/portal.py daylib/workset_api.py