### PR TITLE
Default Cognito setup to Google OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ ursa aws setup                 # Create DynamoDB tables
 ursa aws status                # Check resource status
 ursa aws teardown              # Delete all resources (destructive)
 
-# Cognito authentication
-daycog setup --client-name ursa  # Create Cognito User Pool + app client named "ursa"
+# Cognito authentication (Google-first default)
+./scripts/setup_cognito_google_default.sh  # Uses ~/.config/google_oauth/client_secret_2_...json
 daycog status            # Check Cognito configuration
 daycog list-users        # List users in the configured pool
 daycog set-password --email user@example.com --password 'NewPass123!'

--- a/docs/AUTHENTICATION_SETUP.md
+++ b/docs/AUTHENTICATION_SETUP.md
@@ -84,13 +84,18 @@ Use the `daylily-cognito` operational CLI rather than direct AWS commands:
 
 ```bash
 source ../daylily-cognito/daycog_activate
-daycog setup --name daylily-workset-users --client-name ursa --port 8914 --profile <aws-profile> --region us-west-2
+./scripts/setup_cognito_google_default.sh
 ```
 
 This writes/updates `~/.config/daycog/default.env` with:
 - `COGNITO_REGION`
 - `COGNITO_USER_POOL_ID`
 - `COGNITO_APP_CLIENT_ID`
+
+By default, `./scripts/setup_cognito_google_default.sh` uses:
+- Google OAuth client JSON: `~/.config/google_oauth/client_secret_2_95843944781-d1831sfs0ic2ggmp6t404b958v1nqn40.apps.googleusercontent.com.json`
+- Pool/client: `daylily-ursa-users` / `ursa`
+- Port/region/profile: `8914` / `us-west-2` / `lsmc` (unless `AWS_PROFILE`/`AWS_REGION` are set)
 
 Create a test user:
 

--- a/docs/CUSTOMER_PORTAL.md
+++ b/docs/CUSTOMER_PORTAL.md
@@ -85,7 +85,7 @@ manager.create_customer_table_if_not_exists()
 
 ```bash
 source ../daylily-cognito/daycog_activate
-daycog setup --name daylily-workset-users --client-name ursa --port 8914 --profile <aws-profile> --region us-west-2
+./scripts/setup_cognito_google_default.sh
 daycog add-user user@acme.com --password 'password123'
 ```
 

--- a/docs/GOOGLE_OAUTH_DEFAULT.md
+++ b/docs/GOOGLE_OAUTH_DEFAULT.md
@@ -1,0 +1,32 @@
+# Google OAuth Default For Ursa
+
+Ursa defaults to Google-enabled Cognito setup using:
+
+- OAuth client JSON:
+  `~/.config/google_oauth/client_secret_2_95843944781-d1831sfs0ic2ggmp6t404b958v1nqn40.apps.googleusercontent.com.json`
+- Cognito pool/client:
+  `daylily-ursa-users` / `ursa`
+- App port:
+  `8914`
+
+## One-command setup
+
+```bash
+source ../daylily-cognito/daycog_activate
+./scripts/setup_cognito_google_default.sh
+```
+
+## Overriding defaults
+
+```bash
+AWS_PROFILE=lsmc AWS_REGION=us-west-2 \
+POOL_NAME=daylily-ursa-users CLIENT_NAME=ursa PORT=8914 \
+GOOGLE_CLIENT_JSON=/path/to/client_secret.json \
+./scripts/setup_cognito_google_default.sh
+```
+
+## Required Google Redirect URI
+
+In Google Cloud Console, the OAuth client must include this URI:
+
+`https://daylily-ursa-5r8giqv5p.auth.us-west-2.amazoncognito.com/oauth2/idpresponse`

--- a/scripts/setup_cognito_google_default.sh
+++ b/scripts/setup_cognito_google_default.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Default Google OAuth client JSON for Ursa Cognito setup.
+DEFAULT_GOOGLE_CLIENT_JSON="${HOME}/.config/google_oauth/client_secret_2_95843944781-d1831sfs0ic2ggmp6t404b958v1nqn40.apps.googleusercontent.com.json"
+
+POOL_NAME="${POOL_NAME:-daylily-ursa-users}"
+CLIENT_NAME="${CLIENT_NAME:-ursa}"
+PORT="${PORT:-8914}"
+AWS_PROFILE_VALUE="${AWS_PROFILE:-lsmc}"
+AWS_REGION_VALUE="${AWS_REGION:-us-west-2}"
+GOOGLE_CLIENT_JSON="${GOOGLE_CLIENT_JSON:-$DEFAULT_GOOGLE_CLIENT_JSON}"
+
+if ! command -v daycog >/dev/null 2>&1; then
+  echo "daycog is not installed or not on PATH"
+  echo "Run: source ../daylily-cognito/daycog_activate"
+  exit 1
+fi
+
+if [[ ! -f "$GOOGLE_CLIENT_JSON" ]]; then
+  echo "Google OAuth client JSON not found:"
+  echo "  $GOOGLE_CLIENT_JSON"
+  echo "Override with: GOOGLE_CLIENT_JSON=/path/to/client_secret.json $0"
+  exit 1
+fi
+
+echo "Configuring Cognito + Google OAuth for Ursa..."
+echo "  pool:    $POOL_NAME"
+echo "  client:  $CLIENT_NAME"
+echo "  port:    $PORT"
+echo "  profile: $AWS_PROFILE_VALUE"
+echo "  region:  $AWS_REGION_VALUE"
+echo "  google:  $GOOGLE_CLIENT_JSON"
+
+AWS_PROFILE="$AWS_PROFILE_VALUE" AWS_REGION="$AWS_REGION_VALUE" \
+daycog setup-with-google \
+  --name "$POOL_NAME" \
+  --client-name "$CLIENT_NAME" \
+  --profile "$AWS_PROFILE_VALUE" \
+  --region "$AWS_REGION_VALUE" \
+  --port "$PORT" \
+  --google-client-json "$GOOGLE_CLIENT_JSON"
+
+echo
+echo "Done. Recommended next step:"
+echo "  cp ~/.config/daycog/${POOL_NAME}.${AWS_REGION_VALUE}.${CLIENT_NAME}.env ~/.config/daycog/default.env"


### PR DESCRIPTION
## Summary
- add Configuring Cognito + Google OAuth for Ursa...
  pool:    daylily-ursa-users
  client:  ursa
  port:    8914
  profile: lsmc
  region:  us-west-2
  google:  /Users/jmajor/.config/google_oauth/client_secret_2_95843944781-d1831sfs0ic2ggmp6t404b958v1nqn40.apps.googleusercontent.com.json
Creating Cognito resources...
Profile: lsmc
Region: us-west-2
⚠  User pool 'daylily-ursa-users' already exists
⚠  Pool already has domain 'daylily-ursa-5r8giqv5p' (requested 
'daylily-ursa-users'). Keeping existing domain.
✓  Created app client: 34g35v8tpurbe309a8e5t5ot7i
⚠  Config file already exists, updating: 
/Users/jmajor/.config/daycog/daylily-ursa-users.us-west-2.env
⚠  Config file already exists, updating: 
/Users/jmajor/.config/daycog/daylily-ursa-users.us-west-2.ursa.env
⚠  Config file already exists, updating: 
/Users/jmajor/.config/daycog/default.env

✓  Cognito setup complete

Saved config files:
   /Users/jmajor/.config/daycog/daylily-ursa-users.us-west-2.env
   /Users/jmajor/.config/daycog/daylily-ursa-users.us-west-2.ursa.env (app)
   /Users/jmajor/.config/daycog/default.env (default)

Values written to default config:
   COGNITO_USER_POOL_ID=us-west-2_5r8gIqV5P
   COGNITO_APP_CLIENT_ID=34g35v8tpurbe309a8e5t5ot7i
   COGNITO_CALLBACK_URL=http://localhost:8914/auth/callback
   COGNITO_DOMAIN=daylily-ursa-5r8giqv5p.auth.us-west-2.amazoncognito.com
✓  Updated Google identity provider
✓  Enabled Google provider on app client: ursa (34g35v8tpurbe309a8e5t5ot7i)
✓  Setup with Google IdP complete

Done. Recommended next step:
  cp ~/.config/daycog/daylily-ursa-users.us-west-2.ursa.env ~/.config/daycog/default.env as the default daycog setup path
- default to Google OAuth client JSON at 
- update auth docs and README to use the Google-first setup flow
- add  with required redirect URI

## Notes
- wrapper script still allows overrides via , , , , , and .