### PR TITLE
Ensure ursa_activate prefers the local checkout

### DIFF
--- a/ursa_activate
+++ b/ursa_activate
@@ -167,6 +167,21 @@ if [ "$_URSA_ACTIVATE_OK" -eq 1 ]; then
             ;;
     esac
 
+    # Ensure this checkout wins over any stale site-packages copy when
+    # console scripts like `ursa` import `daylib`.
+    case ":${PYTHONPATH}:" in
+        *":${SCRIPT_DIR}:"*)
+            ;;
+        *)
+            if [ -n "${PYTHONPATH}" ]; then
+                export PYTHONPATH="${SCRIPT_DIR}:${PYTHONPATH}"
+            else
+                export PYTHONPATH="${SCRIPT_DIR}"
+            fi
+            log_success "Added ${SCRIPT_DIR} to PYTHONPATH"
+            ;;
+    esac
+
     # ========== Install Package in Development Mode ==========
     log_info "Installing ursa in development mode..."
     if pip install -e "${SCRIPT_DIR}" -q 2>/dev/null; then


### PR DESCRIPTION
## Summary
- prepend the repository root to `PYTHONPATH` during `source ./ursa_activate`
- ensure console scripts like `ursa` import `daylib` from the current checkout instead of a stale site-packages copy

## Validation
- `sh -n ./ursa_activate`
- `source ./ursa_activate && python -c 'import daylib, sys; print(daylib.__file__); print(sys.path[:5])'`

## Notes
- change is limited to `ursa_activate`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author