### PR TITLE
Pin daylily-tapdb to 0.1.33

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     # Cognito auth library
     "daylily-cognito>=0.1.24",
     # TapDB graph persistence
-    "daylily-tapdb>=0.1.28,<0.2.0",
+    "daylily-tapdb==0.1.33",
     "fastapi>=0.104.0",
     "uvicorn[standard]>=0.24.0",
     "pydantic>=2.0.0",


### PR DESCRIPTION
## Summary
- pin `daylily-tapdb` to `0.1.33` in `pyproject.toml`
- refresh editable install metadata so generated requirements reflect the exact pin
- verify the installed TapDB package version and run a focused TapDB backend test

## Validation
- `source ./ursa_activate && pytest tests/test_tapdb_backend.py -q`
- `source ./ursa_activate && python -c 'from importlib.metadata import version; print(version("daylily-tapdb"))'`
- `source ./ursa_activate && tapdb version`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author