### PR TITLE
chore(ci): align ursa checks and bump tapdb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,45 +1,177 @@
 name: CI
 
 on:
-  pull_request:
   push:
-    branches:
-      - main
+    branches: ['*']
+  pull_request:
+    branches: [main]
 
 permissions:
   contents: read
 
-jobs:
-  test-lint-typecheck:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11"]
+env:
+  PYTHON_VERSION: "3.11"
 
+jobs:
+  lint:
+    name: Code Quality (Ruff)
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
 
-      - name: Install
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Collect changed Python files
+        id: changed
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import subprocess
+
+          def collect_files(command):
+              result = subprocess.run(command, capture_output=True, check=False, text=True)
+              if result.returncode == 0:
+                  return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+              return None
+
+          event = os.environ["GITHUB_EVENT_NAME"]
+          if event == "pull_request":
+              with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as fh:
+                  payload = json.load(fh)
+              base_sha = payload["pull_request"]["base"]["sha"]
+              head_sha = payload["pull_request"]["head"]["sha"]
+              files = collect_files(["git", "diff", "--name-only", f"{base_sha}...{head_sha}", "--", "*.py"])
+              if files is None:
+                  files = collect_files(["git", "diff", "--name-only", f"{base_sha}..{head_sha}", "--", "*.py"])
+              if files is None:
+                  files = []
+          else:
+              has_parent = subprocess.run(
+                  ["git", "rev-parse", "--verify", "HEAD^"],
+                  stdout=subprocess.DEVNULL,
+                  stderr=subprocess.DEVNULL,
+              ).returncode == 0
+              if has_parent:
+                  files = collect_files(["git", "diff", "--name-only", "HEAD^", "HEAD", "--", "*.py"]) or []
+              else:
+                  files = collect_files(["git", "ls-files", "*.py"]) or []
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"files={json.dumps(files)}\n")
+              fh.write(f"count={len(files)}\n")
+          PY
+
+      - name: Run ruff check
+        if: steps.changed.outputs.count != '0'
+        run: ruff check ${{ join(fromJson(steps.changed.outputs.files), ' ') }}
+
+      - name: Run ruff format check
+        if: steps.changed.outputs.count != '0'
+        run: ruff format --check ${{ join(fromJson(steps.changed.outputs.files), ' ') }}
+
+      - name: Skip ruff when no Python files changed
+        if: steps.changed.outputs.count == '0'
+        run: echo "No Python file changes detected."
+
+  security:
+    name: Security Scanning (Bandit)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install bandit
+        run: pip install "bandit[toml]"
+
+      - name: Collect changed Python files
+        id: changed
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import subprocess
+
+          def collect_files(command):
+              result = subprocess.run(command, capture_output=True, check=False, text=True)
+              if result.returncode == 0:
+                  return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+              return None
+
+          event = os.environ["GITHUB_EVENT_NAME"]
+          if event == "pull_request":
+              with open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8") as fh:
+                  payload = json.load(fh)
+              base_sha = payload["pull_request"]["base"]["sha"]
+              head_sha = payload["pull_request"]["head"]["sha"]
+              files = collect_files(["git", "diff", "--name-only", f"{base_sha}...{head_sha}", "--", "*.py"])
+              if files is None:
+                  files = collect_files(["git", "diff", "--name-only", f"{base_sha}..{head_sha}", "--", "*.py"])
+              if files is None:
+                  files = []
+          else:
+              has_parent = subprocess.run(
+                  ["git", "rev-parse", "--verify", "HEAD^"],
+                  stdout=subprocess.DEVNULL,
+                  stderr=subprocess.DEVNULL,
+              ).returncode == 0
+              if has_parent:
+                  files = collect_files(["git", "diff", "--name-only", "HEAD^", "HEAD", "--", "*.py"]) or []
+              else:
+                  files = collect_files(["git", "ls-files", "*.py"]) or []
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"files={json.dumps(files)}\n")
+              fh.write(f"count={len(files)}\n")
+          PY
+
+      - name: Run bandit security scan
+        if: steps.changed.outputs.count != '0'
+        run: bandit -c pyproject.toml ${{ join(fromJson(steps.changed.outputs.files), ' ') }}
+
+      - name: Skip bandit when no Python files changed
+        if: steps.changed.outputs.count == '0'
+        run: echo "No Python file changes detected."
+
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           python -m pip install ".[dev]"
 
-      - name: Unit tests
+      - name: Run beta-critical tests
         run: |
-          pytest -q
-
-      - name: Lint (ruff)
-        run: |
-          ruff check daylib tests
-
-      - name: Typecheck (mypy)
-        run: |
-          mypy daylib
+          pytest -q \
+            tests/test_tapdb_backend.py \
+            tests/test_file_metadata.py \
+            tests/test_analysis_ingest.py \
+            tests/test_result_return.py \
+            tests/test_bloom_resolver_client.py \
+            tests/test_console_scripts.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# Pre-commit hooks for daylily-ursa
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.1
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.9.4
+    hooks:
+      - id: bandit
+        args: ["-c", "pyproject.toml"]
+        additional_dependencies: ["bandit[toml]"]

--- a/config/ecosystem-versions.json
+++ b/config/ecosystem-versions.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "last_updated": "2026-03-04",
+  "last_updated": "2026-03-08",
   "components": {
     "daylily-ursa": {
       "repo": "Daylily-Informatics/daylily-ursa",
@@ -20,7 +20,7 @@
     },
     "daylily-tapdb": {
       "repo": "Daylily-Informatics/daylily-tapdb",
-      "current": "0.1.28"
+      "current": "0.1.35"
     },
     "daylily-omics-references": {
       "repo": "Daylily-Informatics/daylily-omics-references",
@@ -57,6 +57,16 @@
       "tapdb": "0.1.28",
       "omics_references": "0.3.1",
       "notes": "Bumped TapDB baseline to strict-namespace 0.1.28"
+    },
+    {
+      "date": "2026-03-08",
+      "ursa": "0.1.7",
+      "ephemeral_cluster": "0.7.601",
+      "omics_analysis": "0.7.602",
+      "cognito": "0.1.24",
+      "tapdb": "0.1.35",
+      "omics_references": "0.3.1",
+      "notes": "Pinned TapDB baseline to 0.1.35 for the beta contract"
     }
   ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     # Cognito auth library
     "daylily-cognito>=0.1.24",
     # TapDB graph persistence
-    "daylily-tapdb==0.1.33",
+    "daylily-tapdb==0.1.35",
     "fastapi>=0.104.0",
     "uvicorn[standard]>=0.24.0",
     "pydantic>=2.0.0",
@@ -92,3 +92,6 @@ warn_unused_configs = true
 disallow_untyped_defs = false
 ignore_missing_imports = true
 no_site_packages = true
+
+[tool.bandit]
+skips = ["B101"]


### PR DESCRIPTION
## Summary\n- align daylily-ursa commit safety checks with the Atlas-style lint/security/test job split\n- add pre-commit Ruff and Bandit hooks\n- pin daylily-tapdb to 0.1.35 and update ecosystem version metadata\n\n## Validation\n- source ./ursa_activate && python -m pre_commit run --files .github/workflows/ci.yml .pre-commit-config.yaml pyproject.toml config/ecosystem-versions.json\n- source ./ursa_activate && python -m ruff check daylib tests\n- source ./ursa_activate && pytest -q tests/test_tapdb_backend.py tests/test_file_metadata.py tests/test_analysis_ingest.py tests/test_result_return.py tests/test_bloom_resolver_client.py tests/test_console_scripts.py