### PR TITLE
Add PostgreSQL tooling to Ursa env

### DIFF
--- a/config/ursa_env.yaml
+++ b/config/ursa_env.yaml
@@ -16,6 +16,7 @@ dependencies:
   - yaml
   - setuptools<81
   - awscli==2.22.4
+  - postgresql
   - nodejs
   - pip
   - pip:


### PR DESCRIPTION
## Summary
- add PostgreSQL tooling to the Ursa environment configuration
- make local DB setup and debugging work without extra manual package installs