### PR TITLE
Bump TapDB compatibility baseline to 0.2.5

### DIFF
--- a/config/ecosystem-versions.json
+++ b/config/ecosystem-versions.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "1",
-  "last_updated": "2026-03-08",
+  "last_updated": "2026-03-24",
   "components": {
     "daylily-ursa": {
       "repo": "Daylily-Informatics/daylily-ursa",
-      "current": "0.1.7"
+      "current": "0.2.5"
     },
     "daylily-ephemeral-cluster": {
       "repo": "Daylily-Informatics/daylily-ephemeral-cluster",
@@ -20,7 +20,7 @@
     },
     "daylily-tapdb": {
       "repo": "Daylily-Informatics/daylily-tapdb",
-      "current": "0.1.35"
+      "current": "0.2.5"
     },
     "daylily-omics-references": {
       "repo": "Daylily-Informatics/daylily-omics-references",
@@ -67,6 +67,16 @@
       "tapdb": "0.1.35",
       "omics_references": "0.3.1",
       "notes": "Pinned TapDB baseline to 0.1.35 for the beta contract"
+    },
+    {
+      "date": "2026-03-24",
+      "ursa": "0.2.5",
+      "ephemeral_cluster": "0.7.601",
+      "omics_analysis": "0.7.602",
+      "cognito": "0.1.24",
+      "tapdb": "0.2.5",
+      "omics_references": "0.3.1",
+      "notes": "Promoted TapDB baseline to 0.2.5 for user-writable namespaced socket directories"
     }
   ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     # Cognito auth library
     "daylily-cognito>=0.1.24",
     # TapDB graph persistence
-    "daylily-tapdb==0.1.35",
+    "daylily-tapdb==0.2.5",
     "fastapi>=0.104.0",
     "uvicorn[standard]>=0.24.0",
     "pydantic>=2.0.0",


### PR DESCRIPTION
## Summary
- bump the TapDB compatibility baseline to 0.2.5
- update the pinned ecosystem version metadata

## Why
- preserves the existing release-train work as a normal reviewed PR before starting the separate Ursa activation fix branch

## Validation
- preserved existing clean pushed branch state
- no additional code changes made in this PR

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author