### PR TITLE
[codex] Use YAML-only Cognito config and deployment chrome

### DIFF
--- a/config/ursa-config.example.yaml
+++ b/config/ursa-config.example.yaml
@@ -12,13 +12,7 @@
 # NOTE: S3 buckets are discovered from cluster tags (aws-parallelcluster-monitor-bucket)
 # rather than being configured here. Each cluster's bucket is set during cluster creation.
 #
-# Environment variables take precedence over config file values:
-# - AWS_PROFILE overrides aws_profile
-# - COGNITO_REGION overrides cognito_region
-# - COGNITO_USER_POOL_ID overrides cognito_user_pool_id
-# - COGNITO_APP_CLIENT_ID overrides cognito_app_client_id
-
-# AWS profile to use (overridden by AWS_PROFILE env var if set)
+# AWS profile to use (AWS_PROFILE may still override this)
 aws_profile: lsmc
 
 # List of AWS regions to scan for ParallelCluster instances
@@ -49,7 +43,16 @@ regions:
 #   tapdb config init --client-id local --database-name ursa --env dev
 #   tapdb bootstrap local
 
-# Cognito configuration (overridden by env vars COGNITO_USER_POOL_ID, COGNITO_APP_CLIENT_ID, COGNITO_REGION)
+# Cognito configuration is read from this YAML file.
 # cognito_user_pool_id: us-west-2_xxxxxxxx
 # cognito_app_client_id: xxxxxxxxxxxxxxxxxxxxxxxxxx
 # cognito_region: us-west-2  # AWS region where Cognito User Pool is deployed
+# cognito_domain: your-domain-prefix.auth.us-west-2.amazoncognito.com
+# cognito_callback_url: https://localhost:8914/auth/callback
+# cognito_logout_url: https://localhost:8914/login
+
+# Non-production deployment chrome
+deployment:
+  name: ""
+  color: "#0f766e"
+  is_production: false

--- a/daylib_ursa/cli/server.py
+++ b/daylib_ursa/cli/server.py
@@ -141,26 +141,29 @@ def _describe_cognito_app_client(
     return dict(response.get("UserPoolClient") or {})
 
 
-def _require_cognito_configuration(ursa_config) -> None:
-    """Require Cognito configuration and project it into env vars."""
+def _require_cognito_configuration(ursa_config) -> dict[str, str]:
+    """Require Cognito configuration from YAML config without exporting env vars."""
     field_map = {
-        "COGNITO_USER_POOL_ID": "cognito_user_pool_id",
-        "COGNITO_APP_CLIENT_ID": "cognito_app_client_id",
-        "COGNITO_REGION": "cognito_region",
-        "COGNITO_DOMAIN": "cognito_domain",
+        "cognito_user_pool_id": "Cognito user pool ID",
+        "cognito_app_client_id": "Cognito app client ID",
+        "cognito_region": "Cognito region",
+        "cognito_domain": "Cognito domain",
+        "cognito_callback_url": "Cognito callback URL",
+        "cognito_logout_url": "Cognito logout URL",
     }
     missing: list[str] = []
-    for env_key, attr_name in field_map.items():
-        if not os.environ.get(env_key):
-            value = getattr(ursa_config, attr_name, None)
-            if value:
-                os.environ[env_key] = str(value)
-            else:
-                missing.append(env_key)
+    resolved: dict[str, str] = {}
+    for attr_name, label in field_map.items():
+        value = str(getattr(ursa_config, attr_name, "") or "").strip()
+        if value:
+            resolved[attr_name] = value
+        else:
+            missing.append(label)
     if missing:
         console.print("[red]✗[/red]  Authentication is mandatory but Cognito config is missing")
-        console.print("   Missing: [cyan]" + ", ".join(missing) + "[/cyan]")
+        console.print("   Missing YAML fields: [cyan]" + ", ".join(missing) + "[/cyan]")
         raise typer.Exit(1)
+    return resolved
 
 
 def _get_pid() -> Optional[int]:
@@ -183,13 +186,16 @@ def _get_pid() -> Optional[int]:
 
 
 
-def _run_cognito_uri_check(port: int, host: str, aws_profile: str) -> None:
-    """Validate Cognito app-client callback/logout URIs match runtime port."""
-    user_pool_id = os.environ.get("COGNITO_USER_POOL_ID", "")
-    app_client_id = os.environ.get("COGNITO_APP_CLIENT_ID", "")
-    region = os.environ.get("COGNITO_REGION", os.environ.get("AWS_REGION", "us-west-2"))
-    if not user_pool_id or not app_client_id:
-        return
+def _run_cognito_uri_check(
+    port: int,
+    host: str,
+    aws_profile: str,
+    cognito_config: dict[str, str],
+) -> None:
+    """Validate Cognito app-client callback/logout URIs match YAML configuration."""
+    user_pool_id = cognito_config["cognito_user_pool_id"]
+    app_client_id = cognito_config["cognito_app_client_id"]
+    region = cognito_config["cognito_region"]
     try:
         app_client = _describe_cognito_app_client(
             profile=aws_profile,
@@ -202,8 +208,8 @@ def _run_cognito_uri_check(port: int, host: str, aws_profile: str) -> None:
         return
 
     oauth_host = runtime_oauth_host(host)
-    expected_callback = f"https://{oauth_host}:{port}/auth/callback"
-    expected_logout = f"https://{oauth_host}:{port}/"
+    expected_callback = cognito_config["cognito_callback_url"]
+    expected_logout = cognito_config["cognito_logout_url"]
     errors = validate_cognito_app_client(
         app_client=app_client,
         expected_callback_url=expected_callback,
@@ -262,10 +268,10 @@ def start(
         os.environ["AWS_PROFILE"] = aws_profile
 
     _require_auth_dependencies()
-    _require_cognito_configuration(ursa_config)
+    cognito_config = _require_cognito_configuration(ursa_config)
 
     if check_cognito_uris:
-        _run_cognito_uri_check(port, host, aws_profile or "default")
+        _run_cognito_uri_check(port, host, aws_profile or "default", cognito_config)
 
     aws_region = (
         os.environ.get("AWS_REGION")

--- a/daylib_ursa/config.py
+++ b/daylib_ursa/config.py
@@ -19,6 +19,30 @@ from daylib_ursa.domain_access import (
 )
 
 
+def _yaml_seed_from_ursa_config() -> dict[str, object]:
+    """Seed YAML-owned runtime settings from Ursa config before env resolution."""
+    try:
+        from daylib_ursa.ursa_config import get_ursa_config
+
+        cfg = get_ursa_config()
+    except Exception:
+        return {}
+
+    return {
+        "aws_profile": cfg.aws_profile,
+        "cognito_user_pool_id": cfg.cognito_user_pool_id,
+        "cognito_app_client_id": cfg.cognito_app_client_id,
+        "cognito_app_client_secret": cfg.cognito_app_client_secret,
+        "cognito_domain": cfg.cognito_domain,
+        "cognito_region": cfg.cognito_region,
+        "cognito_callback_url": cfg.cognito_callback_url,
+        "cognito_logout_url": cfg.cognito_logout_url,
+        "deployment_name": cfg.deployment_name,
+        "deployment_color": cfg.deployment_color,
+        "deployment_is_production": cfg.deployment_is_production,
+    }
+
+
 def _require_https_url(value: str, *, field_name: str) -> str:
     normalized = str(value or "").strip()
     if not normalized:
@@ -169,6 +193,18 @@ class Settings(BaseSettings):
         default=None,
         description="AWS Cognito Hosted UI domain (optional, used for SSO/OAuth flows)",
     )
+    cognito_region: Optional[str] = Field(
+        default=None,
+        description="AWS region where the Cognito User Pool is deployed",
+    )
+    cognito_callback_url: Optional[str] = Field(
+        default=None,
+        description="Explicit HTTPS callback URL registered for Cognito Hosted UI",
+    )
+    cognito_logout_url: Optional[str] = Field(
+        default=None,
+        description="Explicit HTTPS logout redirect URL registered for Cognito Hosted UI",
+    )
     enable_auth: bool = Field(
         default=True,
         description="Authentication is mandatory and always enabled",
@@ -194,6 +230,18 @@ class Settings(BaseSettings):
     daylily_env: str = Field(
         default="development",
         description="Environment: development, staging, production",
+    )
+    deployment_name: str = Field(
+        default="",
+        description="Deployment name shown in non-production UI chrome",
+    )
+    deployment_color: str = Field(
+        default="#0f766e",
+        description="Deployment banner color shown in non-production UI chrome",
+    )
+    deployment_is_production: bool = Field(
+        default=False,
+        description="Whether this deployment should hide non-production chrome",
     )
 
     # ========== Demo Mode ==========
@@ -416,6 +464,13 @@ class Settings(BaseSettings):
     def validate_dewey_base_url(cls, v: str) -> str:
         return _validate_optional_https_url(v, field_name="dewey_base_url")
 
+    @field_validator("cognito_callback_url", "cognito_logout_url")
+    @classmethod
+    def validate_optional_cognito_urls(cls, v: Optional[str], info) -> Optional[str]:
+        if v is None:
+            return None
+        return _validate_optional_https_url(v, field_name=str(info.field_name))
+
     @model_validator(mode="after")
     def validate_dewey_integration(self) -> "Settings":
         if self.dewey_enabled:
@@ -459,7 +514,7 @@ class Settings(BaseSettings):
     @property
     def is_production(self) -> bool:
         """Check if running in production environment."""
-        return self.daylily_env == "production"
+        return self.daylily_env == "production" or self.deployment_is_production
 
     @property
     def is_development(self) -> bool:
@@ -483,6 +538,14 @@ class Settings(BaseSettings):
     def auth_configured(self) -> bool:
         """Check if authentication is properly configured."""
         return bool(self.cognito_user_pool_id and self.cognito_app_client_id)
+
+    @property
+    def deployment(self) -> dict[str, object]:
+        return {
+            "name": self.deployment_name,
+            "color": self.deployment_color,
+            "is_production": self.deployment_is_production,
+        }
 
     def get_rate_limit_whitelist(self) -> List[str]:
         """Get list of whitelisted IPs/user IDs for rate limiting."""
@@ -593,7 +656,7 @@ def get_settings() -> Settings:
     Settings are loaded once and cached for the lifetime of the application.
     Use this function as a FastAPI dependency.
     """
-    return Settings()
+    return Settings(**_yaml_seed_from_ursa_config())
 
 
 def clear_settings_cache() -> None:
@@ -610,4 +673,6 @@ def get_settings_for_testing(**overrides) -> Settings:
 
     This bypasses the cache, allowing tests to use custom configuration.
     """
-    return Settings(**overrides)
+    payload = _yaml_seed_from_ursa_config()
+    payload.update(overrides)
+    return Settings(**payload)

--- a/daylib_ursa/gui/static/favicon.svg
+++ b/daylib_ursa/gui/static/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Ursa">
+  <rect width="64" height="64" rx="14" fill="#12263a"/>
+  <circle cx="18" cy="20" r="4" fill="#00d9a6"/>
+  <circle cx="28" cy="14" r="4" fill="#00d9a6"/>
+  <circle cx="40" cy="18" r="4" fill="#00d9a6"/>
+  <circle cx="36" cy="30" r="4" fill="#00d9a6"/>
+  <circle cx="46" cy="40" r="4" fill="#ff6b6b"/>
+  <circle cx="54" cy="48" r="4" fill="#ff6b6b"/>
+  <path d="M18 20L28 14L40 18L36 30" fill="none" stroke="#f4f7fb" stroke-opacity=".4" stroke-width="2.5"/>
+  <path d="M40 18L46 40L54 48" fill="none" stroke="#f4f7fb" stroke-opacity=".4" stroke-width="2.5"/>
+</svg>

--- a/daylib_ursa/gui/templates/base.html
+++ b/daylib_ursa/gui/templates/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Ursa customer portal">
     <title>{{ page_title }} | Ursa</title>
+    <link rel="icon" href="/ui/static/favicon.svg" type="image/svg+xml">
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -15,6 +16,9 @@
     {% block extra_head %}{% endblock %}
 </head>
 <body>
+    {% if deployment and not deployment.is_production and deployment.name %}
+    <div style="height:18px;line-height:18px;background:{{ deployment.color }};color:#ffffff;text-align:center;font-size:11px;font-weight:700;letter-spacing:0.12em;text-transform:uppercase;">{{ deployment.name|upper }}</div>
+    {% endif %}
     <header class="header">
         <div class="container">
             <div class="header-content">

--- a/daylib_ursa/gui/templates/login.html
+++ b/daylib_ursa/gui/templates/login.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Login | Ursa</title>
+    <link rel="icon" href="/ui/static/favicon.svg" type="image/svg+xml">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
@@ -11,6 +12,9 @@
     <link rel="stylesheet" href="{{ request.url_for('ui-static', path='main.css') }}">
 </head>
 <body>
+    {% if deployment and not deployment.is_production and deployment.name %}
+    <div style="height:18px;line-height:18px;background:{{ deployment.color }};color:#ffffff;text-align:center;font-size:11px;font-weight:700;letter-spacing:0.12em;text-transform:uppercase;">{{ deployment.name|upper }}</div>
+    {% endif %}
     <main class="login-shell">
         <section class="login-card">
             <div class="page-header" style="margin-bottom: 2rem;">

--- a/daylib_ursa/gui_app.py
+++ b/daylib_ursa/gui_app.py
@@ -19,6 +19,14 @@ def mount_gui(app: FastAPI) -> None:
     if static_root.is_dir():
         app.mount("/ui/static", StaticFiles(directory=str(static_root)), name="ui-static")
 
+    def _deployment_context() -> dict[str, object]:
+        settings = getattr(app.state, "settings", None)
+        return {
+            "name": str(getattr(settings, "deployment_name", "") or ""),
+            "color": str(getattr(settings, "deployment_color", "#0f766e") or "#0f766e"),
+            "is_production": bool(getattr(settings, "deployment_is_production", False)),
+        }
+
     def _next_path(raw_value: str | None) -> str:
         value = str(raw_value or "").strip()
         return value if value.startswith("/") else "/"
@@ -94,6 +102,7 @@ def mount_gui(app: FastAPI) -> None:
             "active_page": active_page,
             "secondary_page": secondary_page,
             "page_data_json": json.dumps(context or {}, default=_json_default),
+            "deployment": _deployment_context(),
         }
         template_context.update(context or {})
         return templates.TemplateResponse(request, template_name, template_context)
@@ -374,6 +383,7 @@ def mount_gui(app: FastAPI) -> None:
                 "request": request,
                 "next_path": _next_path(next),
                 "error": None,
+                "deployment": _deployment_context(),
             },
         )
 
@@ -392,6 +402,7 @@ def mount_gui(app: FastAPI) -> None:
                     "request": request,
                     "next_path": _next_path(next_path),
                     "error": "Atlas access token is required",
+                    "deployment": _deployment_context(),
                 },
                 status_code=status.HTTP_400_BAD_REQUEST,
             )
@@ -405,11 +416,16 @@ def mount_gui(app: FastAPI) -> None:
                     "request": request,
                     "next_path": _next_path(next_path),
                     "error": str(exc),
+                    "deployment": _deployment_context(),
                 },
                 status_code=status.HTTP_401_UNAUTHORIZED,
             )
         request.session["atlas_access_token"] = token
         return RedirectResponse(url=_next_path(next_path), status_code=status.HTTP_303_SEE_OTHER)
+
+    @app.get("/favicon.ico", include_in_schema=False)
+    async def favicon_redirect() -> RedirectResponse:
+        return RedirectResponse(url="/ui/static/favicon.svg", status_code=status.HTTP_307_TEMPORARY_REDIRECT)
 
     @app.get("/logout")
     async def logout(request: Request):

--- a/daylib_ursa/ursa_config.py
+++ b/daylib_ursa/ursa_config.py
@@ -3,7 +3,7 @@
 This module provides:
 - List of AWS regions to scan for ParallelCluster instances
 - Per-region SSH key configuration for multi-region cluster access
-- AWS profile and Cognito settings (overridden by environment variables)
+- AWS profile plus YAML-owned Cognito and deployment settings
 
 S3 buckets are discovered from cluster tags (aws-parallelcluster-monitor-bucket)
 rather than being configured statically per region.
@@ -63,7 +63,10 @@ VALID_FIELDS = {
     "cognito_app_client_id": (str, "Cognito App Client ID"),
     "cognito_app_client_secret": (str, "Cognito App Client Secret"),
     "cognito_domain": (str, "Cognito Hosted UI domain"),
+    "cognito_callback_url": (str, "Cognito Hosted UI callback URL"),
+    "cognito_logout_url": (str, "Cognito Hosted UI logout redirect URL"),
     "whitelist_domains": (str, "Allowed email domains for registration/login"),
+    "deployment": (dict, "Deployment metadata for non-production UI chrome"),
 }
 
 
@@ -146,6 +149,8 @@ def validate_config_file(path: Path) -> Tuple[bool, List[str], List[str]]:
         "cognito_app_client_id",
         "cognito_app_client_secret",
         "cognito_domain",
+        "cognito_callback_url",
+        "cognito_logout_url",
         "whitelist_domains",
     ]:
         if field_name in data and data[field_name] is not None:
@@ -173,25 +178,40 @@ class UrsaConfig:
     """List of region configurations to scan for ParallelCluster instances."""
 
     aws_profile: Optional[str] = None
-    """AWS profile to use (overridden by AWS_PROFILE env var)."""
+    """AWS profile to use (AWS_PROFILE may still override this)."""
 
     cognito_user_pool_id: Optional[str] = None
-    """Cognito User Pool ID (overridden by COGNITO_USER_POOL_ID env var)."""
+    """Cognito User Pool ID read from YAML config."""
 
     cognito_app_client_id: Optional[str] = None
-    """Cognito App Client ID (overridden by COGNITO_APP_CLIENT_ID env var)."""
+    """Cognito App Client ID read from YAML config."""
 
     cognito_app_client_secret: Optional[str] = None
-    """Cognito App Client Secret (overridden by COGNITO_APP_CLIENT_SECRET env var)."""
+    """Cognito App Client Secret read from YAML config."""
 
     cognito_domain: Optional[str] = None
-    """Cognito Hosted UI domain (overridden by COGNITO_DOMAIN env var)."""
+    """Cognito Hosted UI domain read from YAML config."""
 
     cognito_region: Optional[str] = None
-    """AWS region where Cognito User Pool is deployed (overridden by COGNITO_REGION env var)."""
+    """AWS region where Cognito User Pool is deployed, read from YAML config."""
+
+    cognito_callback_url: Optional[str] = None
+    """Cognito Hosted UI callback URL, read from YAML config."""
+
+    cognito_logout_url: Optional[str] = None
+    """Cognito Hosted UI logout redirect URL, read from YAML config."""
 
     whitelist_domains: Optional[str] = None
     """Allowed registration/login email domains (overridden by WHITELIST_DOMAINS env var)."""
+
+    deployment_name: str = ""
+    """Deployment name shown in non-production UI chrome."""
+
+    deployment_color: str = "#0f766e"
+    """Deployment banner color shown in non-production UI chrome."""
+
+    deployment_is_production: bool = False
+    """Whether deployment chrome should be hidden."""
 
     _config_path: Optional[Path] = None
     """Path where config was loaded from."""
@@ -206,14 +226,8 @@ class UrsaConfig:
     def load(cls, config_path: Optional[Path] = None) -> "UrsaConfig":
         """Load configuration from YAML file.
 
-        Environment variables take precedence over config file values:
-        - AWS_PROFILE overrides aws_profile
-        - COGNITO_USER_POOL_ID overrides cognito_user_pool_id
-        - COGNITO_APP_CLIENT_ID overrides cognito_app_client_id
-        - COGNITO_APP_CLIENT_SECRET overrides cognito_app_client_secret
-        - COGNITO_DOMAIN overrides cognito_domain
-        - COGNITO_REGION overrides cognito_region
-        - WHITELIST_DOMAINS overrides whitelist_domains
+        AWS_PROFILE and WHITELIST_DOMAINS may override config file values.
+        Cognito runtime settings are read from YAML only.
 
         Args:
             config_path: Path to config file. If not provided, looks for
@@ -304,19 +318,19 @@ class UrsaConfig:
                 ", ".join(region_map.keys()),
             )
 
-        # Environment variables take precedence over config file
+        deployment = data.get("deployment") or {}
+        if not isinstance(deployment, dict):
+            deployment = {}
+
+        # Environment variables take precedence only for non-Cognito runtime knobs.
         aws_profile = os.environ.get("AWS_PROFILE") or data.get("aws_profile")
-        cognito_user_pool_id = os.environ.get("COGNITO_USER_POOL_ID") or data.get(
-            "cognito_user_pool_id"
-        )
-        cognito_app_client_id = os.environ.get("COGNITO_APP_CLIENT_ID") or data.get(
-            "cognito_app_client_id"
-        )
-        cognito_app_client_secret = os.environ.get("COGNITO_APP_CLIENT_SECRET") or data.get(
-            "cognito_app_client_secret"
-        )
-        cognito_domain = os.environ.get("COGNITO_DOMAIN") or data.get("cognito_domain")
-        cognito_region = os.environ.get("COGNITO_REGION") or data.get("cognito_region")
+        cognito_user_pool_id = data.get("cognito_user_pool_id")
+        cognito_app_client_id = data.get("cognito_app_client_id")
+        cognito_app_client_secret = data.get("cognito_app_client_secret")
+        cognito_domain = data.get("cognito_domain")
+        cognito_region = data.get("cognito_region")
+        cognito_callback_url = data.get("cognito_callback_url")
+        cognito_logout_url = data.get("cognito_logout_url")
         whitelist_domains = os.environ.get("WHITELIST_DOMAINS") or data.get("whitelist_domains")
 
         config = cls(
@@ -327,7 +341,12 @@ class UrsaConfig:
             cognito_app_client_secret=cognito_app_client_secret,
             cognito_domain=cognito_domain,
             cognito_region=cognito_region,
+            cognito_callback_url=cognito_callback_url,
+            cognito_logout_url=cognito_logout_url,
             whitelist_domains=whitelist_domains,
+            deployment_name=str(deployment.get("name") or ""),
+            deployment_color=str(deployment.get("color") or "#0f766e"),
+            deployment_is_production=bool(deployment.get("is_production", False)),
             _config_path=path,
             _from_legacy_path=from_legacy,
             _region_map=region_map,
@@ -389,16 +408,16 @@ class UrsaConfig:
         return os.environ.get("AWS_PROFILE") or self.aws_profile
 
     def get_effective_cognito_region(self) -> Optional[str]:
-        """Get the effective Cognito region (env var or config).
+        """Get the configured Cognito region.
 
         Returns:
             Cognito region, or None if not configured.
         """
-        return os.environ.get("COGNITO_REGION") or self.cognito_region
+        return self.cognito_region
 
     def get_effective_cognito_domain(self) -> Optional[str]:
-        """Get the effective Cognito Hosted UI domain (env var or config)."""
-        return os.environ.get("COGNITO_DOMAIN") or self.cognito_domain
+        """Get the configured Cognito Hosted UI domain."""
+        return self.cognito_domain
 
     def get_value_source(self, field: str) -> str:
         """Get the source of a configuration value.
@@ -411,11 +430,6 @@ class UrsaConfig:
         """
         env_map = {
             "aws_profile": "AWS_PROFILE",
-            "cognito_region": "COGNITO_REGION",
-            "cognito_user_pool_id": "COGNITO_USER_POOL_ID",
-            "cognito_app_client_id": "COGNITO_APP_CLIENT_ID",
-            "cognito_app_client_secret": "COGNITO_APP_CLIENT_SECRET",
-            "cognito_domain": "COGNITO_DOMAIN",
             "whitelist_domains": "WHITELIST_DOMAINS",
         }
 

--- a/tests/test_cli_server_helpers.py
+++ b/tests/test_cli_server_helpers.py
@@ -166,7 +166,7 @@ def test_validate_cognito_oauth_uris_reports_mismatch() -> None:
     assert any("Expected callback URI is not configured" in error for error in errors)
 
 
-def test_require_cognito_configuration_sets_env_from_config(
+def test_require_cognito_configuration_reads_yaml_only_fields(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     cfg = SimpleNamespace(
@@ -174,6 +174,8 @@ def test_require_cognito_configuration_sets_env_from_config(
         cognito_app_client_id="client",
         cognito_region="us-west-2",
         cognito_domain="example.auth.us-west-2.amazoncognito.com",
+        cognito_callback_url="https://localhost:8914/auth/callback",
+        cognito_logout_url="https://localhost:8914/login",
     )
     for key in (
         "COGNITO_USER_POOL_ID",
@@ -181,14 +183,15 @@ def test_require_cognito_configuration_sets_env_from_config(
         "COGNITO_REGION",
         "COGNITO_DOMAIN",
     ):
-        monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv(key, f"env-{key.lower()}")
 
-    server_cli._require_cognito_configuration(cfg)
+    resolved = server_cli._require_cognito_configuration(cfg)
 
-    assert os.environ["COGNITO_USER_POOL_ID"] == "pool"
-    assert os.environ["COGNITO_APP_CLIENT_ID"] == "client"
-    assert os.environ["COGNITO_REGION"] == "us-west-2"
-    assert "amazoncognito.com" in os.environ["COGNITO_DOMAIN"]
+    assert resolved["cognito_user_pool_id"] == "pool"
+    assert resolved["cognito_app_client_id"] == "client"
+    assert resolved["cognito_region"] == "us-west-2"
+    assert resolved["cognito_callback_url"] == "https://localhost:8914/auth/callback"
+    assert os.environ["COGNITO_USER_POOL_ID"] == "env-cognito_user_pool_id"
 
 
 def test_require_cognito_configuration_raises_when_missing(
@@ -199,6 +202,8 @@ def test_require_cognito_configuration_raises_when_missing(
         cognito_app_client_id="",
         cognito_region="",
         cognito_domain="",
+        cognito_callback_url="",
+        cognito_logout_url="",
     )
     for key in (
         "COGNITO_USER_POOL_ID",
@@ -266,4 +271,3 @@ def test_stop_permission_error_exits(monkeypatch: pytest.MonkeyPatch) -> None:
         server_cli.stop()
 
     assert exc.value.exit_code == 1
-

--- a/tests/test_console_scripts.py
+++ b/tests/test_console_scripts.py
@@ -59,6 +59,8 @@ def test_ursa_server_start_uses_packaged_entrypoint(monkeypatch):
         cognito_app_client_id = "test-app-client"
         cognito_region = "us-west-2"
         cognito_domain = "ursa-auth"
+        cognito_callback_url = "https://localhost:8914/auth/callback"
+        cognito_logout_url = "https://localhost:8914/login"
 
         def get_allowed_regions(self):
             return ["us-west-2"]
@@ -67,8 +69,10 @@ def test_ursa_server_start_uses_packaged_entrypoint(monkeypatch):
     monkeypatch.setattr(ursa_config_mod, "get_ursa_config", lambda reload=False: DummyUrsaConfig())
     monkeypatch.setattr(server_mod, "_ensure_dir", lambda: None)
     monkeypatch.setattr(server_mod, "_get_pid", lambda: None)
-    monkeypatch.setattr(server_mod, "_source_env_file", lambda: False)
+    monkeypatch.setattr(server_mod, "source_env_file", lambda _path: False)
     monkeypatch.setattr(server_mod, "_resolve_https_cert_paths", lambda host: ("/tmp/cert.pem", "/tmp/key.pem"))
+    monkeypatch.setattr(server_mod, "_require_auth_dependencies", lambda: None)
+    monkeypatch.setattr(server_mod, "_run_cognito_uri_check", lambda *args, **kwargs: None)
 
     captured: dict[str, object] = {}
 
@@ -114,6 +118,8 @@ def test_ursa_server_start_allows_ambient_credentials(monkeypatch):
         cognito_app_client_id = "test-app-client"
         cognito_region = "us-west-2"
         cognito_domain = "ursa-auth"
+        cognito_callback_url = "https://localhost:8914/auth/callback"
+        cognito_logout_url = "https://localhost:8914/login"
 
         def get_allowed_regions(self):
             return ["us-west-2"]
@@ -122,8 +128,10 @@ def test_ursa_server_start_allows_ambient_credentials(monkeypatch):
     monkeypatch.setattr(ursa_config_mod, "get_ursa_config", lambda reload=False: DummyUrsaConfig())
     monkeypatch.setattr(server_mod, "_ensure_dir", lambda: None)
     monkeypatch.setattr(server_mod, "_get_pid", lambda: None)
-    monkeypatch.setattr(server_mod, "_source_env_file", lambda: False)
+    monkeypatch.setattr(server_mod, "source_env_file", lambda _path: False)
     monkeypatch.setattr(server_mod, "_resolve_https_cert_paths", lambda host: ("/tmp/cert.pem", "/tmp/key.pem"))
+    monkeypatch.setattr(server_mod, "_require_auth_dependencies", lambda: None)
+    monkeypatch.setattr(server_mod, "_run_cognito_uri_check", lambda *args, **kwargs: None)
 
     captured: dict[str, object] = {}
 

--- a/tests/test_deployment_chrome.py
+++ b/tests/test_deployment_chrome.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+from daylib_ursa.config import clear_settings_cache, get_settings, get_settings_for_testing
+from daylib_ursa.gui_app import mount_gui
+
+
+def test_get_settings_reads_cognito_and_deployment_from_yaml_not_env(tmp_path, monkeypatch):
+    config_path = tmp_path / "ursa-config.yaml"
+    config_path.write_text(
+        """
+aws_profile: lsmc
+ursa_internal_output_bucket: ursa-internal
+cognito_user_pool_id: yaml-pool
+cognito_app_client_id: yaml-client
+cognito_app_client_secret: yaml-secret
+cognito_domain: yaml.auth.us-west-2.amazoncognito.com
+cognito_region: us-west-2
+cognito_callback_url: https://localhost:8914/auth/callback
+cognito_logout_url: https://localhost:8914/login
+deployment:
+  name: staging
+  color: "#124e78"
+  is_production: false
+""".strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("daylib_ursa.ursa_config.DEFAULT_CONFIG_PATH", config_path)
+    monkeypatch.setattr("daylib_ursa.ursa_config.LEGACY_CONFIG_PATHS", [])
+    monkeypatch.setattr("daylib_ursa.ursa_config._global_config", None)
+    monkeypatch.setenv("COGNITO_USER_POOL_ID", "env-pool")
+    monkeypatch.setenv("COGNITO_APP_CLIENT_ID", "env-client")
+    monkeypatch.setenv("COGNITO_DOMAIN", "env.example.com")
+    monkeypatch.setenv("COGNITO_REGION", "eu-west-1")
+    monkeypatch.setenv("URSA_INTERNAL_OUTPUT_BUCKET", "ursa-internal")
+
+    clear_settings_cache()
+    settings = get_settings()
+
+    assert settings.cognito_user_pool_id == "yaml-pool"
+    assert settings.cognito_app_client_id == "yaml-client"
+    assert settings.cognito_app_client_secret == "yaml-secret"
+    assert settings.cognito_domain == "yaml.auth.us-west-2.amazoncognito.com"
+    assert settings.cognito_region == "us-west-2"
+    assert settings.cognito_callback_url == "https://localhost:8914/auth/callback"
+    assert settings.cognito_logout_url == "https://localhost:8914/login"
+    assert settings.deployment == {
+        "name": "staging",
+        "color": "#124e78",
+        "is_production": False,
+    }
+
+
+def _app_with_gui(settings):
+    from fastapi import FastAPI
+    from starlette.middleware.sessions import SessionMiddleware
+
+    app = FastAPI()
+    app.add_middleware(SessionMiddleware, secret_key="test-secret")
+    app.state.settings = settings
+    app.state.identity_client = SimpleNamespace(resolve_access_token=lambda _token: None)
+    mount_gui(app)
+    return app
+
+
+def test_login_page_renders_banner_and_favicon():
+    settings = get_settings_for_testing(
+        ursa_internal_output_bucket="ursa-internal",
+        deployment_name="staging",
+        deployment_color="#124e78",
+        deployment_is_production=False,
+    )
+    client = TestClient(_app_with_gui(settings))
+
+    response = client.get("/login")
+
+    assert response.status_code == 200
+    assert "STAGING" in response.text
+    assert "#124e78" in response.text
+    assert "/ui/static/favicon.svg" in response.text
+
+
+def test_favicon_route_redirects_to_svg():
+    client = TestClient(_app_with_gui(get_settings_for_testing(ursa_internal_output_bucket="ursa-internal")))
+
+    response = client.get("/favicon.ico", follow_redirects=False)
+
+    assert response.status_code == 307
+    assert response.headers["location"] == "/ui/static/favicon.svg"


### PR DESCRIPTION
## What changed
- moved Ursa Cognito runtime reads to YAML-owned config fields on the current `daylib_ursa/...` layout
- removed Cognito env export from server startup, added callback/logout YAML fields, and kept HTTPS-only validation
- added non-production deployment banner and favicon support to the active GUI templates
- added focused regression coverage for config loading, server helpers, console startup, and GUI chrome

## Why
- remove mixed env/YAML Cognito configuration state
- keep active Ursa GUI surfaces visibly marked outside production and consistently branded

## Validation
- `source /tmp/codex-ursa-venv312/bin/activate && python -m pytest tests/test_cli_server_helpers.py tests/test_console_scripts.py tests/test_deployment_chrome.py`
- result: 21 passed