### PR TITLE
[codex] Pin Ursa to TapDB 3.0.3

### DIFF
--- a/config/ecosystem-versions.json
+++ b/config/ecosystem-versions.json
@@ -20,7 +20,7 @@
     },
     "daylily-tapdb": {
       "repo": "Daylily-Informatics/daylily-tapdb",
-      "current": "0.2.5"
+      "current": "3.0.3"
     },
     "daylily-omics-references": {
       "repo": "Daylily-Informatics/daylily-omics-references",
@@ -77,6 +77,16 @@
       "tapdb": "3.0.2",
       "omics_references": "0.3.1",
       "notes": "Pinned TapDB baseline to 3.0.2"
+    },
+    {
+      "date": "2026-03-27",
+      "ursa": "0.2.12",
+      "ephemeral_cluster": "0.7.601",
+      "omics_analysis": "0.7.602",
+      "cognito": "0.1.28",
+      "tapdb": "3.0.3",
+      "omics_references": "0.3.1",
+      "notes": "Pinned TapDB baseline to 3.0.3"
     }
   ]
 }

--- a/config/ursa_env.yaml
+++ b/config/ursa_env.yaml
@@ -27,7 +27,7 @@ dependencies:
       - connexion==2.13.1
       - -e ../../cli-core-yo
       - daylily-cognito>=0.1.28
-      - daylily-tapdb==3.0.2
+      - daylily-tapdb==3.0.3
       - flask==2.2.5
       - httpx
       - itsdangerous>=2.2.0

--- a/daylib_ursa/cli/__init__.py
+++ b/daylib_ursa/cli/__init__.py
@@ -103,7 +103,7 @@ def _ensure_tapdb_dependency() -> None:
     except TapDBRuntimeError as exc:
         raise SystemExit(
             "Ursa CLI startup failed. "
-            "Install daylily-tapdb==3.0.2 or use the supported local editable override. "
+            "Install daylily-tapdb==3.0.3 or use the supported local editable override. "
             f"Details: {exc}"
         ) from exc
 

--- a/daylib_ursa/integrations/tapdb_runtime.py
+++ b/daylib_ursa/integrations/tapdb_runtime.py
@@ -14,7 +14,7 @@ from urllib.parse import quote
 
 from daylily_tapdb import InstanceFactory, TAPDBConnection, TemplateManager
 
-TAPDB_REQUIRED_VERSION = "3.0.2"
+TAPDB_REQUIRED_VERSION = "3.0.3"
 DEFAULT_AWS_PROFILE = "lsmc"
 DEFAULT_AWS_REGION = "us-west-2"
 DEFAULT_TAPDB_CLIENT_ID = "ursa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     # Cognito auth library
     "daylily-cognito>=0.1.28",
     # TapDB graph persistence
-    "daylily-tapdb==3.0.2",
+    "daylily-tapdb==3.0.3",
     "fastapi>=0.104.0",
     "uvicorn[standard]>=0.24.0",
     "pydantic>=2.0.0",

--- a/tests/test_activation_metadata.py
+++ b/tests/test_activation_metadata.py
@@ -24,6 +24,6 @@ def test_ursa_activate_uses_conda_only_bootstrap() -> None:
     assert 'ENV_FILE="${SCRIPT_DIR}/config/ursa_env.yaml"' in activate_script
     assert 'conda env create -n "$CONDA_ENV_NAME" -f "$ENV_FILE"' in activate_script
     assert 'conda activate "$CONDA_ENV_NAME"' in activate_script
-    assert "git+file://${TAPDB_LOCAL_REPO}@3.0.2" in activate_script
+    assert 'require_python_import "daylily_tapdb" "daylily-tapdb==3.0.3"' in activate_script
     assert ".venv" not in activate_script
     assert "[auth,cluster,dev,tools]" not in activate_script

--- a/tests/test_tapdb_backend.py
+++ b/tests/test_tapdb_backend.py
@@ -89,7 +89,7 @@ def test_tapdb_env_for_target_uses_explicit_defaults(monkeypatch) -> None:
 
 
 def test_export_database_url_for_target_sets_runtime_environment(monkeypatch) -> None:
-    monkeypatch.setattr(tapdb_runtime, "ensure_tapdb_version", lambda *_args, **_kwargs: "3.0.2")
+    monkeypatch.setattr(tapdb_runtime, "ensure_tapdb_version", lambda *_args, **_kwargs: "3.0.3")
     monkeypatch.setattr(
         tapdb_runtime,
         "_get_tapdb_db_config_for_env",

--- a/ursa-conformance-directive.md
+++ b/ursa-conformance-directive.md
@@ -27,7 +27,7 @@ Ursa is a **peer service** to Atlas and Bloom. It MUST NOT invent its own patter
 1. **Delete** the `UrsaTapdbRepository` import and its fallback stub entirely.
 2. **Delete** `_MINIMUM_TAPDB_VERSION`, `_MAXIMUM_TAPDB_MAJOR`, `_validate_tapdb_version()`.
 3. **Model after Atlas's `app/integrations/tapdb_runtime.py`:**
-   - Pin `TAPDB_REQUIRED_VERSION = "3.0.2"` (or current 3.x release).
+   - Pin `TAPDB_REQUIRED_VERSION = "3.0.3"` (or current 3.x release).
    - Use `ensure_tapdb_version()` with the same semver + local-override logic Atlas uses.
    - Import from `daylily_tapdb` 3.x surface: `TAPDBConnection`, `TemplateManager`, `InstanceFactory`.
    - Implement a `TapdbClientBundle` dataclass holding `connection`, `template_manager`, `instance_factory`.
@@ -43,7 +43,7 @@ Ursa is a **peer service** to Atlas and Bloom. It MUST NOT invent its own patter
 
 ```python
 # app/integrations/tapdb_runtime.py — Atlas reference
-TAPDB_REQUIRED_VERSION = "3.0.2"
+TAPDB_REQUIRED_VERSION = "3.0.3"
 DEFAULT_TAPDB_CLIENT_ID = "atlas"        # Ursa: "ursa"
 DEFAULT_TAPDB_DATABASE_NAME = "lsmc-atlas"  # Ursa: "daylily-ursa"
 

--- a/ursa_activate
+++ b/ursa_activate
@@ -219,7 +219,7 @@ ursa_activate_main() {
     require_tool "conda env" "psql" || return 1
     require_tool "conda env" "node" || return 1
     require_tool "conda env" "ipython" || return 1
-    require_python_import "daylily_tapdb" "daylily-tapdb==3.0.2" || return 1
+    require_python_import "daylily_tapdb" "daylily-tapdb==3.0.3" || return 1
     require_python_import "daylily_cognito" "daylily-cognito>=0.1.28" || return 1
     require_python_import "cli_core_yo" "../cli-core-yo" || return 1
     require_python_import "fastapi" "fastapi" || return 1


### PR DESCRIPTION
## Summary
- pin Ursa to `daylily-tapdb==3.0.3` across the package metadata, activation script, conda env, and runtime guard
- refresh the runtime/version tests and the TapDB ecosystem metadata for the new baseline
- keep the repo on the current TapDB 3.x-only contract without adding compatibility shims

## Validation
- `source ./ursa_activate && ruff check daylib_ursa/integrations/tapdb_runtime.py daylib_ursa/cli/__init__.py tests/test_tapdb_backend.py tests/test_activation_metadata.py`
- `source ./ursa_activate && PYTHONPATH=/Users/jmajor/projects/daylily/daylily-tapdb pytest tests/test_tapdb_backend.py tests/test_activation_metadata.py -q`