### PR TITLE
Add Ursa Cognito Hosted UI browser login

### DIFF
--- a/config/ursa-config.example.yaml
+++ b/config/ursa-config.example.yaml
@@ -52,6 +52,7 @@ atlas_base_url: https://localhost:8915
 atlas_verify_ssl: true
 dewey_enabled: false
 dewey_base_url: ""
+dewey_api_token: ""
 dewey_verify_ssl: true
 
 # Cognito configuration is read from this YAML file.

--- a/daylib_ursa/cli/server.py
+++ b/daylib_ursa/cli/server.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 
 server_app = typer.Typer(help="API server management commands")
 console = Console()
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
 # PID and log file locations (XDG Base Directory: ~/.config/ursa/)
 CONFIG_DIR = Path.home() / ".config" / "ursa"
@@ -55,7 +56,7 @@ def _resolved_server_host_port(
         if port is not None
         else os.environ.get(
             "URSA_RUNTIME__PORT",
-            os.environ.get("URSA_PORT", getattr(settings, "api_port", 8914)),
+            getattr(settings, "api_port", os.environ.get("URSA_PORT", 8914)),
         )
     )
     resolved_host = str(
@@ -63,7 +64,7 @@ def _resolved_server_host_port(
         if host is not None
         else os.environ.get(
             "URSA_RUNTIME__HOST",
-            os.environ.get("URSA_HOST", getattr(settings, "api_host", "0.0.0.0")),
+            getattr(settings, "api_host", os.environ.get("URSA_HOST", "0.0.0.0")),
         )
     )
     return resolved_host, resolved_port
@@ -272,7 +273,7 @@ def start(
     _ensure_dir()
 
     # Source .env file
-    if source_env_file(Path.cwd() / ".env"):
+    if source_env_file(PROJECT_ROOT / ".env"):
         console.print("[dim]Loaded .env file[/dim]")
 
     settings = get_settings()
@@ -375,7 +376,7 @@ def start(
             stdout=log_f,
             stderr=subprocess.STDOUT,
             start_new_session=True,
-            cwd=Path.cwd(),
+            cwd=PROJECT_ROOT,
             env=env,
         )
 
@@ -401,7 +402,7 @@ def start(
         console.print(f"[green]✓[/green]  Starting server on [cyan]https://{host}:{port}[/cyan]")
         console.print("   Press Ctrl+C to stop\n")
         try:
-            result = subprocess.run(cmd, cwd=Path.cwd(), env=env)
+            result = subprocess.run(cmd, cwd=PROJECT_ROOT, env=env)
             if result.returncode != 0:
                 raise typer.Exit(result.returncode)
         except KeyboardInterrupt:

--- a/daylib_ursa/config.py
+++ b/daylib_ursa/config.py
@@ -49,6 +49,7 @@ def _yaml_seed_from_ursa_config() -> dict[str, object]:
         "atlas_verify_ssl": cfg.atlas_verify_ssl,
         "dewey_enabled": cfg.dewey_enabled,
         "dewey_base_url": cfg.dewey_base_url,
+        "dewey_api_token": cfg.dewey_api_token,
         "dewey_verify_ssl": cfg.dewey_verify_ssl,
         "deployment_name": cfg.deployment_name,
         "deployment_color": cfg.deployment_color,

--- a/daylib_ursa/gui/templates/login.html
+++ b/daylib_ursa/gui/templates/login.html
@@ -29,16 +29,14 @@
                 <div>{{ error }}</div>
             </div>
             {% endif %}
-            <form method="post" action="/login">
-                <input type="hidden" name="next_path" value="{{ next_path }}">
-                <div class="form-group">
-                    <label for="access_token" class="form-label">Authentication Token</label>
-                    <input id="access_token" name="access_token" class="form-control" required autofocus>
-                </div>
-                <div class="toolbar">
-                    <button class="btn btn-primary" type="submit"><i class="fa-solid fa-right-to-bracket"></i> Sign In</button>
-                </div>
-            </form>
+            <p class="page-subtitle" style="margin-bottom: 1.5rem;">
+                Sign in through Cognito Hosted UI to access the Ursa operator portal.
+            </p>
+            <div class="toolbar">
+                <a class="btn btn-primary" href="{{ cognito_login_url }}">
+                    <i class="fa-solid fa-right-to-bracket"></i> Sign In with Cognito
+                </a>
+            </div>
         </section>
     </main>
 </body>

--- a/daylib_ursa/gui_app.py
+++ b/daylib_ursa/gui_app.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import json
+import secrets
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlencode
 
+from daylily_cognito import build_authorization_url, exchange_authorization_code
 from fastapi import FastAPI, Form, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
@@ -37,6 +40,64 @@ def mount_gui(app: FastAPI) -> None:
     def _next_path(raw_value: str | None) -> str:
         value = str(raw_value or "").strip()
         return value if value.startswith("/") else "/"
+
+    def _cognito_login_path(next_path: str) -> str:
+        return f"/auth/login?next={_next_path(next_path)}"
+
+    def _oauth_state() -> str:
+        return secrets.token_urlsafe(24)
+
+    def _cognito_settings() -> dict[str, str]:
+        settings = getattr(app.state, "settings", None)
+        values = {
+            "domain": str(getattr(settings, "cognito_domain", "") or "").strip().rstrip("/"),
+            "client_id": str(getattr(settings, "cognito_app_client_id", "") or "").strip(),
+            "client_secret": str(getattr(settings, "cognito_app_client_secret", "") or "").strip(),
+            "callback_url": str(getattr(settings, "cognito_callback_url", "") or "").strip(),
+            "logout_url": str(getattr(settings, "cognito_logout_url", "") or "").strip(),
+        }
+        if values["domain"].startswith("https://"):
+            values["domain"] = values["domain"][len("https://") :]
+        missing = [key for key in ("domain", "client_id", "callback_url", "logout_url") if not values[key]]
+        if missing:
+            raise HTTPException(
+                status_code=503,
+                detail=f"Cognito authentication is not configured: missing {', '.join(missing)}",
+            )
+        return values
+
+    def _build_cognito_login_url(*, state: str) -> str:
+        cognito = _cognito_settings()
+        return build_authorization_url(
+            domain=cognito["domain"],
+            client_id=cognito["client_id"],
+            redirect_uri=cognito["callback_url"],
+            state=state,
+        )
+
+    def _build_cognito_logout_url(*, state: str | None = None) -> str:
+        cognito = _cognito_settings()
+        query = {
+            "client_id": cognito["client_id"],
+            "redirect_uri": cognito["logout_url"],
+            "response_type": "code",
+        }
+        if state:
+            query["state"] = state
+        return f"https://{cognito['domain']}/logout?{urlencode(query)}"
+
+    def _exchange_auth_code(code: str) -> dict[str, Any]:
+        cognito = _cognito_settings()
+        try:
+            return exchange_authorization_code(
+                domain=cognito["domain"],
+                client_id=cognito["client_id"],
+                code=code,
+                redirect_uri=cognito["callback_url"],
+                client_secret=cognito["client_secret"] or None,
+            )
+        except RuntimeError as exc:
+            raise AuthError(str(exc)) from exc
 
     def _session_actor(request: Request) -> CurrentUser | None:
         try:
@@ -453,10 +514,58 @@ def mount_gui(app: FastAPI) -> None:
             {
                 "request": request,
                 "next_path": _next_path(next),
+                "cognito_login_url": _cognito_login_path(next),
                 "error": None,
                 "deployment": _deployment_context(),
             },
         )
+
+    @app.get("/auth/login", include_in_schema=False)
+    async def auth_login(request: Request, next: str = "/"):
+        state = _oauth_state()
+        request.session["ursa_oauth_state"] = state
+        request.session["ursa_post_auth_redirect"] = _next_path(next)
+        return RedirectResponse(
+            url=_build_cognito_login_url(state=state),
+            status_code=status.HTTP_303_SEE_OTHER,
+        )
+
+    @app.get("/auth/callback", include_in_schema=False)
+    async def auth_callback(request: Request, code: str = "", state: str = ""):
+        expected_state = str(request.session.get("ursa_oauth_state") or "").strip()
+        if not code.strip():
+            raise HTTPException(status_code=400, detail="Missing authorization code")
+        if not state.strip() or state.strip() != expected_state:
+            raise HTTPException(status_code=400, detail="Invalid oauth state")
+        try:
+            token_payload = _exchange_auth_code(code.strip())
+            token = str(token_payload.get("id_token") or token_payload.get("access_token") or "").strip()
+            if not token:
+                raise AuthError("Cognito token response missing id_token or access_token")
+            auth_provider = getattr(app.state, "auth_provider", None)
+            if auth_provider is None:
+                raise AuthError("Authentication provider is not configured")
+            actor = auth_provider.resolve_access_token(token)
+        except AuthError as exc:
+            request.session.pop("ursa_oauth_state", None)
+            request.session.pop("ursa_post_auth_redirect", None)
+            return templates.TemplateResponse(
+                request,
+                "login.html",
+                {
+                    "request": request,
+                    "next_path": _next_path(request.query_params.get("next") or "/"),
+                    "cognito_login_url": _cognito_login_path(request.query_params.get("next") or "/"),
+                    "error": str(exc),
+                    "deployment": _deployment_context(),
+                },
+                status_code=status.HTTP_401_UNAUTHORIZED,
+            )
+
+        persist_session_user(request, actor)
+        redirect_to = _next_path(request.session.pop("ursa_post_auth_redirect", "/"))
+        request.session.pop("ursa_oauth_state", None)
+        return RedirectResponse(url=redirect_to, status_code=status.HTTP_303_SEE_OTHER)
 
     @app.post("/login", response_class=HTMLResponse)
     async def login_submit(
@@ -472,6 +581,7 @@ def mount_gui(app: FastAPI) -> None:
                 {
                     "request": request,
                     "next_path": _next_path(next_path),
+                    "cognito_login_url": _cognito_login_path(next_path),
                     "error": "Authentication token is required",
                     "deployment": _deployment_context(),
                 },
@@ -489,6 +599,7 @@ def mount_gui(app: FastAPI) -> None:
                 {
                     "request": request,
                     "next_path": _next_path(next_path),
+                    "cognito_login_url": _cognito_login_path(next_path),
                     "error": str(exc),
                     "deployment": _deployment_context(),
                 },
@@ -506,7 +617,15 @@ def mount_gui(app: FastAPI) -> None:
     @app.get("/logout")
     async def logout(request: Request):
         clear_session_user(request)
-        return RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
+        try:
+            state = _oauth_state()
+            request.session["ursa_oauth_state"] = state
+            return RedirectResponse(
+                url=_build_cognito_logout_url(state=state),
+                status_code=status.HTTP_303_SEE_OTHER,
+            )
+        except HTTPException:
+            return RedirectResponse(url="/login", status_code=status.HTTP_303_SEE_OTHER)
 
     @app.get("/", response_class=HTMLResponse)
     async def dashboard_page(request: Request):

--- a/daylib_ursa/ursa_config.py
+++ b/daylib_ursa/ursa_config.py
@@ -77,6 +77,7 @@ VALID_FIELDS = {
     "atlas_verify_ssl": (bool, "Verify Atlas TLS certificates"),
     "dewey_enabled": (bool, "Enable Dewey integration"),
     "dewey_base_url": (str, "Dewey base URL"),
+    "dewey_api_token": (str, "Dewey API bearer token"),
     "dewey_verify_ssl": (bool, "Verify Dewey TLS certificates"),
     "whitelist_domains": (str, "Allowed email domains for registration/login"),
     "deployment": (dict, "Deployment metadata for non-production UI chrome"),
@@ -272,6 +273,9 @@ class UrsaConfig:
     dewey_base_url: Optional[str] = None
     """Dewey base URL read from YAML config."""
 
+    dewey_api_token: Optional[str] = None
+    """Dewey API bearer token read from YAML config."""
+
     dewey_verify_ssl: Optional[bool] = None
     """Dewey TLS verification flag read from YAML config."""
 
@@ -417,6 +421,7 @@ class UrsaConfig:
         atlas_verify_ssl = data.get("atlas_verify_ssl")
         dewey_enabled = data.get("dewey_enabled")
         dewey_base_url = data.get("dewey_base_url")
+        dewey_api_token = data.get("dewey_api_token")
         dewey_verify_ssl = data.get("dewey_verify_ssl")
         whitelist_domains = os.environ.get("WHITELIST_DOMAINS") or data.get("whitelist_domains")
 
@@ -442,6 +447,7 @@ class UrsaConfig:
             atlas_verify_ssl=atlas_verify_ssl,
             dewey_enabled=dewey_enabled,
             dewey_base_url=dewey_base_url,
+            dewey_api_token=dewey_api_token,
             dewey_verify_ssl=dewey_verify_ssl,
             whitelist_domains=whitelist_domains,
             deployment_name=str(deployment.get("name") or ""),

--- a/tests/test_cli_server_helpers.py
+++ b/tests/test_cli_server_helpers.py
@@ -253,6 +253,42 @@ def test_source_env_file_reads_key_values(
     assert os.environ["Y"] == "two"
 
 
+def test_server_start_sources_repo_root_env_file(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: dict[str, Path] = {}
+
+    monkeypatch.setattr(server_cli, "_ensure_dir", lambda: None)
+    monkeypatch.setattr(server_cli, "get_settings", lambda: SimpleNamespace())
+    monkeypatch.setattr(server_cli, "_resolved_server_host_port", lambda **_kwargs: ("0.0.0.0", 8913))
+    monkeypatch.setattr(server_cli, "_get_pid", lambda: 12345)
+
+    def _fake_source_env_file(path: Path) -> bool:
+        seen["path"] = path
+        return False
+
+    monkeypatch.setattr(server_cli, "source_env_file", _fake_source_env_file)
+
+    server_cli.start()
+
+    assert seen["path"] == server_cli.PROJECT_ROOT / ".env"
+
+
+def test_resolved_server_host_port_prefers_settings_over_legacy_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("URSA_PORT", "8914")
+    monkeypatch.setenv("URSA_HOST", "127.0.0.1")
+    monkeypatch.delenv("URSA_RUNTIME__PORT", raising=False)
+    monkeypatch.delenv("URSA_RUNTIME__HOST", raising=False)
+    monkeypatch.setattr(
+        server_cli,
+        "get_settings",
+        lambda: SimpleNamespace(api_port=8913, api_host="0.0.0.0"),
+    )
+
+    host, port = server_cli._resolved_server_host_port()
+
+    assert host == "0.0.0.0"
+    assert port == 8913
+
+
 def test_stop_handles_missing_pid(monkeypatch: pytest.MonkeyPatch) -> None:
     # stop() delegates to stop_pid imported into server_cli namespace
     monkeypatch.setattr(server_cli, "stop_pid", lambda _pf: (False, "No PID file"))

--- a/tests/test_deployment_chrome.py
+++ b/tests/test_deployment_chrome.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import uuid
 from types import SimpleNamespace
 
 from fastapi.testclient import TestClient
 
+from daylib_ursa.auth import CurrentUser
 from daylib_ursa.config import clear_settings_cache, get_settings, get_settings_for_testing
+from daylib_ursa import gui_app
 from daylib_ursa.gui_app import mount_gui
 
 
@@ -14,6 +17,19 @@ def test_get_settings_reads_cognito_and_deployment_from_yaml_not_env(tmp_path, m
         """
 aws_profile: lsmc
 ursa_internal_output_bucket: ursa-internal
+tapdb_client_id: ursa
+tapdb_database_name: daylily-ursa
+tapdb_env: dev
+api_host: 127.0.0.1
+api_port: 8913
+bloom_base_url: https://localhost:8912
+bloom_verify_ssl: true
+atlas_base_url: https://localhost:8915
+atlas_verify_ssl: true
+dewey_enabled: false
+dewey_base_url: https://localhost:8914
+dewey_api_token: dewey-dev-token
+dewey_verify_ssl: true
 cognito_user_pool_id: yaml-pool
 cognito_app_client_id: yaml-client
 cognito_app_client_secret: yaml-secret
@@ -48,6 +64,7 @@ deployment:
     assert settings.cognito_region == "us-west-2"
     assert settings.cognito_callback_url == "https://localhost:8914/auth/callback"
     assert settings.cognito_logout_url == "https://localhost:8914/login"
+    assert settings.dewey_api_token == "dewey-dev-token"
     assert settings.deployment == {
         "name": "staging",
         "color": "#124e78",
@@ -63,6 +80,15 @@ def _app_with_gui(settings):
     app.add_middleware(SessionMiddleware, secret_key="test-secret")
     app.state.settings = settings
     app.state.identity_client = SimpleNamespace(resolve_access_token=lambda _token: None)
+    app.state.auth_provider = SimpleNamespace(
+        resolve_access_token=lambda _token: CurrentUser(
+            sub="user-123",
+            email="user@example.com",
+            name="Ursa User",
+            tenant_id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+            roles=["ADMIN"],
+        )
+    )
     mount_gui(app)
     return app
 
@@ -73,6 +99,10 @@ def test_login_page_renders_banner_and_favicon():
         deployment_name="staging",
         deployment_color="#124e78",
         deployment_is_production=False,
+        cognito_domain="ursa.auth.us-west-2.amazoncognito.com",
+        cognito_app_client_id="client-123",
+        cognito_callback_url="https://localhost:8913/auth/callback",
+        cognito_logout_url="https://localhost:8913/login",
     )
     client = TestClient(_app_with_gui(settings))
 
@@ -82,6 +112,49 @@ def test_login_page_renders_banner_and_favicon():
     assert "STAGING" in response.text
     assert "#124e78" in response.text
     assert "/ui/static/favicon.svg" in response.text
+    assert "Sign In with Cognito" in response.text
+    assert "/auth/login?next=/" in response.text
+
+
+def test_auth_login_redirects_to_cognito(monkeypatch):
+    settings = get_settings_for_testing(
+        ursa_internal_output_bucket="ursa-internal",
+        cognito_domain="ursa.auth.us-west-2.amazoncognito.com",
+        cognito_app_client_id="client-123",
+        cognito_callback_url="https://localhost:8913/auth/callback",
+        cognito_logout_url="https://localhost:8913/login",
+    )
+    client = TestClient(_app_with_gui(settings))
+
+    monkeypatch.setattr(gui_app.secrets, "token_urlsafe", lambda _n: "state-123")
+    monkeypatch.setattr(gui_app, "build_authorization_url", lambda **_kwargs: "https://example.auth/login")
+    response = client.get("/auth/login?next=/usage", follow_redirects=False)
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "https://example.auth/login"
+
+
+def test_auth_callback_persists_session_and_redirects(monkeypatch):
+    settings = get_settings_for_testing(
+        ursa_internal_output_bucket="ursa-internal",
+        cognito_domain="ursa.auth.us-west-2.amazoncognito.com",
+        cognito_app_client_id="client-123",
+        cognito_callback_url="https://localhost:8913/auth/callback",
+        cognito_logout_url="https://localhost:8913/login",
+    )
+    client = TestClient(_app_with_gui(settings))
+    monkeypatch.setattr(gui_app.secrets, "token_urlsafe", lambda _n: "state-123")
+    monkeypatch.setattr(gui_app, "build_authorization_url", lambda **_kwargs: "https://example.auth/login")
+    client.get("/auth/login?next=/usage", follow_redirects=False)
+    monkeypatch.setattr(gui_app, "exchange_authorization_code", lambda **_kwargs: {"id_token": "token-123"})
+    response = client.get("/auth/callback?code=auth-code&state=state-123", follow_redirects=False)
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/usage"
+
+    login_page = client.get("/login?next=/usage", follow_redirects=False)
+    assert login_page.status_code == 303
+    assert login_page.headers["location"] == "/usage"
 
 
 def test_favicon_route_redirects_to_svg():


### PR DESCRIPTION
## Summary
- replace the token-entry browser login with a Cognito Hosted UI flow
- wire callback/session handling into the existing Ursa auth path
- cover the new flow with CLI and browser-oriented tests

## Testing
- source ./activate && pytest -q tests/test_cli_server_helpers.py tests/test_deployment_chrome.py tests/test_admin_gui_and_cluster_routes.py tests/test_auth_dependencies.py