### PR TITLE
Release Ursa 0.2.18 with TapDB 3.0.9

### DIFF
--- a/activate
+++ b/activate
@@ -286,7 +286,7 @@ activate_main() {
     require_tool "conda env" "psql" || return 1
     require_tool "conda env" "node" || return 1
     require_tool "conda env" "ipython" || return 1
-    require_python_import "daylily_tapdb" "daylily-tapdb==3.0.7" || return 1
+    require_python_import "daylily_tapdb" "daylily-tapdb==3.0.9" || return 1
     require_python_import "daylily_cognito" "daylily-cognito==0.1.30" || return 1
     require_python_import "cli_core_yo" "../cli-core-yo" || return 1
     require_python_import "fastapi" "fastapi" || return 1

--- a/config/ecosystem-versions.json
+++ b/config/ecosystem-versions.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1",
-  "last_updated": "2026-03-27",
+  "last_updated": "2026-03-29",
   "components": {
     "daylily-ursa": {
       "repo": "Daylily-Informatics/daylily-ursa",
@@ -20,7 +20,7 @@
     },
     "daylily-tapdb": {
       "repo": "Daylily-Informatics/daylily-tapdb",
-      "current": "3.0.6"
+      "current": "3.0.9"
     },
     "daylily-omics-references": {
       "repo": "Daylily-Informatics/daylily-omics-references",
@@ -87,6 +87,16 @@
       "tapdb": "3.0.6",
       "omics_references": "0.3.1",
       "notes": "Pinned TapDB baseline to 3.0.6"
+    },
+    {
+      "date": "2026-03-29",
+      "ursa": "0.2.18",
+      "ephemeral_cluster": "0.7.601",
+      "omics_analysis": "0.7.602",
+      "cognito": "0.1.30",
+      "tapdb": "3.0.9",
+      "omics_references": "0.3.1",
+      "notes": "Pinned TapDB baseline to 3.0.9"
     }
   ]
 }

--- a/config/ursa_env.yaml
+++ b/config/ursa_env.yaml
@@ -27,7 +27,7 @@ dependencies:
       - connexion==2.13.1
       - -e ../../cli-core-yo
       - daylily-cognito==0.1.30
-      - daylily-tapdb==3.0.7
+      - daylily-tapdb==3.0.9
       - flask==2.2.5
       - httpx
       - itsdangerous>=2.2.0

--- a/daylib_ursa/auth/dependencies.py
+++ b/daylib_ursa/auth/dependencies.py
@@ -130,6 +130,54 @@ def _normalize_roles(raw_roles: Any) -> list[str]:
     return normalized
 
 
+def _normalize_groups(raw_groups: Any) -> list[str]:
+    if isinstance(raw_groups, str):
+        values = [item for item in raw_groups.split(",") if item.strip()]
+    elif isinstance(raw_groups, (list, tuple, set)):
+        values = [str(item) for item in raw_groups]
+    else:
+        values = []
+
+    groups: list[str] = []
+    seen: set[str] = set()
+    for item in values:
+        clean = str(item or "").strip()
+        if not clean or clean in seen:
+            continue
+        seen.add(clean)
+        groups.append(clean)
+    return groups
+
+
+def _map_cognito_groups_to_roles(raw_groups: Any) -> list[str]:
+    try:
+        from daylib_ursa.config import get_settings
+
+        mapping = get_settings().cognito_group_role_map
+    except Exception:
+        mapping = {
+            "platform-admin": "ADMIN",
+            "ursa-admin": "ADMIN",
+            "ursa-internal": "INTERNAL_USER",
+            "ursa-external-admin": "EXTERNAL_USER_ADMIN",
+            "ursa-external": "EXTERNAL_USER",
+            "ursa-readwrite": "READ_WRITE",
+            "ursa-readonly": "READ_ONLY",
+        }
+
+    roles: list[str] = []
+    seen: set[str] = set()
+    for group in _normalize_groups(raw_groups):
+        role = str(mapping.get(group) or "").strip().upper()
+        if not role or role in seen:
+            continue
+        seen.add(role)
+        roles.append(role)
+    if not roles:
+        roles.append(Role.READ_ONLY.value)
+    return roles
+
+
 def _parse_uuid(value: Any, *, label: str) -> uuid.UUID:
     raw = str(value or "").strip()
     if not raw:
@@ -152,13 +200,13 @@ def _claims_to_current_user(claims: dict[str, Any]) -> CurrentUser:
         or claims.get("custom:customer_id")
     )
     name = str(claims.get("name") or claims.get("display_name") or "").strip() or None
-    raw_roles = claims.get("roles") or claims.get("custom:roles") or claims.get("cognito:groups")
+    raw_roles = claims.get("cognito:groups")
     return CurrentUser(
         sub=sub,
         email=email,
         name=name,
         tenant_id=_parse_uuid(tenant_value, label="tenant_id"),
-        roles=_normalize_roles(raw_roles),
+        roles=_map_cognito_groups_to_roles(raw_roles),
     )
 
 
@@ -338,7 +386,34 @@ class CognitoUserDirectoryService:
                 mapped[name] = value
         return mapped
 
-    def _entry_from_user(self, item: dict[str, Any]) -> AtlasUserDirectoryEntry:
+    def _list_group_names_for_user(self, username: str) -> list[str]:
+        clean_username = str(username or "").strip()
+        if not clean_username:
+            return []
+        next_token: str | None = None
+        groups: list[str] = []
+        while True:
+            kwargs: dict[str, Any] = {
+                "UserPoolId": self.user_pool_id,
+                "Username": clean_username,
+                "Limit": 60,
+            }
+            if next_token:
+                kwargs["NextToken"] = next_token
+            try:
+                response = self._get_client().admin_list_groups_for_user(**kwargs)
+            except ClientError as exc:
+                raise AuthError(f"Cognito user group lookup failed for {clean_username}: {exc}") from exc
+            for item in response.get("Groups") or []:
+                name = str(item.get("GroupName") or "").strip()
+                if name and name not in groups:
+                    groups.append(name)
+            next_token = str(response.get("NextToken") or "").strip() or None
+            if not next_token:
+                break
+        return groups
+
+    def _entry_from_user(self, item: dict[str, Any], group_names: list[str]) -> AtlasUserDirectoryEntry:
         attrs = self._attrs_to_dict(item)
         user_id = str(attrs.get("sub") or "").strip() or str(item.get("Username") or "").strip()
         tenant_id = _parse_uuid(
@@ -347,11 +422,7 @@ class CognitoUserDirectoryService:
             or attrs.get("custom:customer_id"),
             label="tenant_id",
         )
-        roles = tuple(
-            _normalize_roles(
-                attrs.get("custom:roles") or attrs.get("roles") or attrs.get("custom:role") or ""
-            )
-        )
+        roles = tuple(_map_cognito_groups_to_roles(group_names))
         display_name = (
             str(attrs.get("name") or "").strip()
             or str(attrs.get("preferred_username") or "").strip()
@@ -406,7 +477,8 @@ class CognitoUserDirectoryService:
             if not users:
                 break
             for item in users:
-                entry = self._entry_from_user(item)
+                group_names = self._list_group_names_for_user(str(item.get("Username") or ""))
+                entry = self._entry_from_user(item, group_names)
                 if active_only and not entry.is_active:
                     continue
                 if wanted_tenant and entry.tenant_id != wanted_tenant:

--- a/daylib_ursa/cli/__init__.py
+++ b/daylib_ursa/cli/__init__.py
@@ -111,7 +111,7 @@ def _ensure_tapdb_dependency() -> None:
     except TapDBRuntimeError as exc:
         raise SystemExit(
             "Ursa CLI startup failed. "
-            "Install daylily-tapdb==3.0.7 or use the supported local editable override. "
+            "Install daylily-tapdb==3.0.9 or use the supported local editable override. "
             f"Details: {exc}"
         ) from exc
 

--- a/daylib_ursa/config.py
+++ b/daylib_ursa/config.py
@@ -6,6 +6,7 @@ Configuration is loaded once at startup and injected via dependency.
 
 from __future__ import annotations
 
+import json
 import os
 from functools import lru_cache
 from typing import List, Optional
@@ -30,6 +31,8 @@ def _yaml_seed_from_ursa_config() -> dict[str, object]:
 
     return {
         "aws_profile": cfg.aws_profile,
+        "ursa_portal_default_customer_id": cfg.ursa_portal_default_customer_id,
+        "cognito_group_role_map": cfg.cognito_group_role_map,
         "ursa_internal_output_bucket": cfg.ursa_internal_output_bucket,
         "tapdb_client_id": cfg.tapdb_client_id,
         "tapdb_database_name": cfg.tapdb_database_name,
@@ -221,6 +224,18 @@ class Settings(BaseSettings):
     cognito_logout_url: Optional[str] = Field(
         default=None,
         description="Explicit HTTPS logout redirect URL registered for Cognito Hosted UI",
+    )
+    cognito_group_role_map: dict[str, str] = Field(
+        default_factory=lambda: {
+            "platform-admin": "ADMIN",
+            "ursa-admin": "ADMIN",
+            "ursa-internal": "INTERNAL_USER",
+            "ursa-external-admin": "EXTERNAL_USER_ADMIN",
+            "ursa-external": "EXTERNAL_USER",
+            "ursa-readwrite": "READ_WRITE",
+            "ursa-readonly": "READ_ONLY",
+        },
+        description="Mapping from Cognito group names to Ursa auth roles",
     )
     enable_auth: bool = Field(
         default=True,
@@ -506,6 +521,38 @@ class Settings(BaseSettings):
             return None
         return _validate_optional_https_url(v, field_name=str(info.field_name))
 
+    @field_validator("cognito_group_role_map", mode="before")
+    @classmethod
+    def validate_cognito_group_role_map(cls, value: object) -> dict[str, str]:
+        from daylib_ursa.auth.rbac import Role
+
+        if value is None:
+            return {
+                "platform-admin": "ADMIN",
+                "ursa-admin": "ADMIN",
+                "ursa-internal": "INTERNAL_USER",
+                "ursa-external-admin": "EXTERNAL_USER_ADMIN",
+                "ursa-external": "EXTERNAL_USER",
+                "ursa-readwrite": "READ_WRITE",
+                "ursa-readonly": "READ_ONLY",
+            }
+        if isinstance(value, str):
+            value = json.loads(value)
+        if not isinstance(value, dict):
+            raise ValueError("cognito_group_role_map must be a mapping")
+
+        allowed_roles = {role.value for role in Role}
+        normalized: dict[str, str] = {}
+        for group_name, role_name in value.items():
+            group = str(group_name or "").strip()
+            role = str(role_name or "").strip().upper()
+            if not group:
+                raise ValueError("cognito_group_role_map contains an empty group name")
+            if role not in allowed_roles:
+                raise ValueError(f"Unsupported Ursa role in cognito_group_role_map: {role_name!r}")
+            normalized[group] = role
+        return normalized
+
     @model_validator(mode="after")
     def validate_dewey_integration(self) -> "Settings":
         if self.dewey_enabled:
@@ -710,4 +757,6 @@ def get_settings_for_testing(**overrides) -> Settings:
     """
     payload = _yaml_seed_from_ursa_config()
     payload.update(overrides)
+    if payload.get("ursa_portal_default_customer_id") is None:
+        payload.pop("ursa_portal_default_customer_id", None)
     return Settings(**payload)

--- a/daylib_ursa/ursa_config.py
+++ b/daylib_ursa/ursa_config.py
@@ -58,6 +58,8 @@ LEGACY_CONFIG_PATHS = [
 VALID_FIELDS = {
     "regions": (list, "List of AWS regions to scan"),
     "aws_profile": (str, "AWS profile name"),
+    "ursa_portal_default_customer_id": (str, "Fallback customer ID used by the lightweight portal surface"),
+    "cognito_group_role_map": (dict, "Canonical Cognito group-to-role mapping"),
     "ursa_internal_output_bucket": (str, "Ursa-managed internal S3 bucket"),
     "tapdb_client_id": (str, "TapDB client identifier"),
     "tapdb_database_name": (str, "TapDB namespace / database name"),
@@ -215,6 +217,12 @@ class UrsaConfig:
 
     aws_profile: Optional[str] = None
     """AWS profile to use (AWS_PROFILE may still override this)."""
+
+    ursa_portal_default_customer_id: Optional[str] = None
+    """Fallback customer ID used by the lightweight portal surface."""
+
+    cognito_group_role_map: Optional[Dict[str, str]] = None
+    """Optional Cognito group-to-role mapping override loaded from YAML config."""
 
     ursa_internal_output_bucket: Optional[str] = None
     """Ursa-managed internal output bucket read from YAML config."""
@@ -402,6 +410,8 @@ class UrsaConfig:
 
         # Environment variables take precedence only for non-Cognito runtime knobs.
         aws_profile = os.environ.get("AWS_PROFILE") or data.get("aws_profile")
+        ursa_portal_default_customer_id = data.get("ursa_portal_default_customer_id")
+        cognito_group_role_map = data.get("cognito_group_role_map")
         ursa_internal_output_bucket = data.get("ursa_internal_output_bucket")
         tapdb_client_id = data.get("tapdb_client_id")
         tapdb_database_name = data.get("tapdb_database_name")
@@ -428,6 +438,8 @@ class UrsaConfig:
         config = cls(
             regions=region_configs,
             aws_profile=aws_profile,
+            ursa_portal_default_customer_id=ursa_portal_default_customer_id,
+            cognito_group_role_map=cognito_group_role_map,
             ursa_internal_output_bucket=ursa_internal_output_bucket,
             tapdb_client_id=tapdb_client_id,
             tapdb_database_name=tapdb_database_name,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     # Cognito auth library
     "daylily-cognito==0.1.30",
     # TapDB graph persistence
-    "daylily-tapdb==3.0.7",
+    "daylily-tapdb==3.0.9",
     "fastapi>=0.104.0",
     "uvicorn[standard]>=0.24.0",
     "pydantic>=2.0.0",

--- a/tests/test_activation_metadata.py
+++ b/tests/test_activation_metadata.py
@@ -24,6 +24,6 @@ def test_activate_uses_conda_only_bootstrap() -> None:
     assert 'ENV_FILE="${SCRIPT_DIR}/config/ursa_env.yaml"' in activate_script
     assert 'conda env create -n "$CONDA_ENV_NAME" -f "$ENV_FILE"' in activate_script
     assert 'conda activate "$CONDA_ENV_NAME"' in activate_script
-    assert 'require_python_import "daylily_tapdb" "daylily-tapdb==3.0.7"' in activate_script
+    assert 'require_python_import "daylily_tapdb" "daylily-tapdb==3.0.9"' in activate_script
     assert ".venv" not in activate_script
     assert "[auth,cluster,dev,tools]" not in activate_script

--- a/tests/test_auth_dependencies.py
+++ b/tests/test_auth_dependencies.py
@@ -8,13 +8,13 @@ from daylib_ursa.auth import AuthError
 from daylib_ursa.auth import dependencies as auth_dependencies
 
 
-def test_claims_to_current_user_accepts_customer_id_and_groups() -> None:
+def test_claims_to_current_user_maps_canonical_cognito_groups() -> None:
     user = auth_dependencies._claims_to_current_user(
         {
             "sub": "user-123",
             "email": "ursa@example.com",
             "custom:customer_id": "00000000-0000-0000-0000-000000000001",
-            "cognito:groups": ["admin"],
+            "cognito:groups": ["platform-admin"],
         }
     )
 
@@ -39,7 +39,7 @@ def test_cognito_auth_provider_accepts_id_token_claims(monkeypatch) -> None:
             "email": "ursa@example.com",
             "aud": "client-123",
             "custom:customer_id": "00000000-0000-0000-0000-000000000001",
-            "cognito:groups": ["admin"],
+            "cognito:groups": ["ursa-admin"],
         },
     )
 
@@ -53,6 +53,19 @@ def test_cognito_auth_provider_accepts_id_token_claims(monkeypatch) -> None:
 
     assert user.tenant_id == uuid.UUID("00000000-0000-0000-0000-000000000001")
     assert user.roles == ["ADMIN"]
+
+
+def test_claims_to_current_user_maps_external_admin_group() -> None:
+    user = auth_dependencies._claims_to_current_user(
+        {
+            "sub": "user-123",
+            "email": "ursa@example.com",
+            "custom:customer_id": "00000000-0000-0000-0000-000000000001",
+            "cognito:groups": ["ursa-external-admin"],
+        }
+    )
+
+    assert user.roles == ["EXTERNAL_USER_ADMIN"]
 
 
 def test_cognito_auth_provider_rejects_id_token_with_wrong_audience(monkeypatch) -> None:
@@ -75,3 +88,41 @@ def test_cognito_auth_provider_rejects_id_token_with_wrong_audience(monkeypatch)
 
     with pytest.raises(AuthError, match="Invalid token audience"):
         provider.resolve_access_token("token-value")
+
+
+def test_user_directory_uses_cognito_groups_as_role_source() -> None:
+    class _Client:
+        def list_users(self, **_kwargs):
+            return {
+                "Users": [
+                    {
+                        "Username": "user-123",
+                        "Enabled": True,
+                        "UserStatus": "CONFIRMED",
+                        "Attributes": [
+                            {"Name": "sub", "Value": "user-123"},
+                            {"Name": "email", "Value": "ursa@example.com"},
+                            {"Name": "custom:customer_id", "Value": "00000000-0000-0000-0000-000000000001"},
+                            {"Name": "custom:roles", "Value": "READ_ONLY"},
+                        ],
+                    }
+                ]
+            }
+
+        def admin_list_groups_for_user(self, **_kwargs):
+            return {
+                "Groups": [
+                    {"GroupName": "platform-admin"},
+                ]
+            }
+
+    directory = auth_dependencies.CognitoUserDirectoryService(
+        user_pool_id="pool-123",
+        region="us-west-2",
+    )
+    directory._client = _Client()
+
+    users = directory.list_users(active_only=False, limit=10)
+
+    assert len(users) == 1
+    assert users[0].roles == ("ADMIN",)

--- a/tests/test_deployment_chrome.py
+++ b/tests/test_deployment_chrome.py
@@ -22,6 +22,7 @@ tapdb_database_name: daylily-ursa
 tapdb_env: dev
 api_host: 127.0.0.1
 api_port: 8913
+ursa_portal_default_customer_id: 77777777-7777-7777-7777-777777777777
 bloom_base_url: https://localhost:8912
 bloom_verify_ssl: true
 atlas_base_url: https://localhost:8915
@@ -65,6 +66,7 @@ deployment:
     assert settings.cognito_callback_url == "https://localhost:8914/auth/callback"
     assert settings.cognito_logout_url == "https://localhost:8914/login"
     assert settings.dewey_api_token == "dewey-dev-token"
+    assert settings.ursa_portal_default_customer_id == "77777777-7777-7777-7777-777777777777"
     assert settings.deployment == {
         "name": "staging",
         "color": "#124e78",

--- a/tests/test_domain_access.py
+++ b/tests/test_domain_access.py
@@ -80,10 +80,10 @@ def test_ursa_rejects_disallowed_origin() -> None:
     assert response.text == "Origin not allowed"
 
 
-def test_ursa_rejects_disallowed_host() -> None:
+def test_ursa_allows_arbitrary_host_when_host_filtering_is_delegated_upstream() -> None:
     app = create_app(DummyStore(), bloom_client=DummyBloomClient(), settings=_settings())
 
     with TestClient(app) as client:
         response = client.get("/healthz", headers={"host": "evil.example.com"})
 
-    assert response.status_code == 400
+    assert response.status_code == 200

--- a/tests/test_tapdb_mount.py
+++ b/tests/test_tapdb_mount.py
@@ -48,6 +48,7 @@ def _fake_tapdb_app() -> FastAPI:
 def _settings(*, mount_enabled: bool = True) -> Settings:
     return Settings(
         cors_origins="*",
+        aws_profile=None,
         ursa_internal_api_key="test-key",
         bloom_base_url="https://bloom.example",
         atlas_base_url="https://atlas.example",


### PR DESCRIPTION
## Summary
- bump Ursa's TapDB requirement from 3.0.7 to 3.0.9
- include the current auth and route coverage worktree
- refresh Ursa ecosystem metadata for the new TapDB baseline

## Validation
- source ./activate && pytest -q tests/test_activation_metadata.py tests/test_auth_dependencies.py tests/test_deployment_chrome.py tests/test_domain_access.py tests/test_tapdb_mount.py