### PR TITLE
Add Ursa anomaly registry surfaces

### DIFF
--- a/config/tapdb_templates/ursa/templates.json
+++ b/config/tapdb_templates/ursa/templates.json
@@ -208,6 +208,19 @@
       "bstatus": "active",
       "is_singleton": false,
       "json_addl": {}
+    },
+    {
+      "name": "Ursa Local Anomaly Record",
+      "polymorphic_discriminator": "generic_template",
+      "category": "ops",
+      "type": "anomaly",
+      "subtype": "local-record",
+      "version": "1.0",
+      "instance_prefix": "ANM",
+      "instance_polymorphic_identity": "generic_instance",
+      "bstatus": "active",
+      "is_singleton": false,
+      "json_addl": {}
     }
   ]
 }

--- a/daylib_ursa/anomalies.py
+++ b/daylib_ursa/anomalies.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from daylib_ursa.config import Settings
+from daylib_ursa.resource_store import ResourceStore
+from daylib_ursa.tapdb_graph import from_json_addl, utc_now_iso
+from daylib_ursa.tapdb_templates import seed_ursa_templates
+
+ANOMALY_TEMPLATE = "ops/anomaly/local-record/1.0/"
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _fingerprint(value: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    return hashlib.sha1(text.encode("utf-8")).hexdigest()[:12]
+
+
+def _environment_name(settings: Settings) -> str:
+    return (
+        str(settings.deployment_name or "").strip()
+        or str(settings.tapdb_env or "").strip()
+        or str(settings.database_target or "").strip()
+        or "unknown"
+    )
+
+
+def redact_context(value: Any) -> Any:
+    if isinstance(value, dict):
+        redacted: dict[str, Any] = {}
+        for key, item in value.items():
+            lowered = str(key).lower()
+            if lowered in {"authorization", "cookie", "set-cookie", "token", "secret", "password"}:
+                redacted[str(key)] = "[redacted]"
+            elif lowered == "sql":
+                redacted[str(key)] = "[redacted-sql]"
+            else:
+                redacted[str(key)] = redact_context(item)
+        return redacted
+    if isinstance(value, list):
+        return [redact_context(item) for item in value]
+    if isinstance(value, str):
+        return value
+    return value
+
+
+@dataclass(frozen=True)
+class AnomalyRecord:
+    id: str
+    service: str
+    environment: str
+    category: str
+    severity: str
+    fingerprint: str
+    summary: str
+    first_seen_at: str
+    last_seen_at: str
+    occurrence_count: int
+    redacted_context: dict[str, Any]
+    source_view_url: str
+
+
+class AnomalyRepository:
+    def __init__(self, *, backend: Any, resource_store: ResourceStore | None, settings: Settings) -> None:
+        self.resource_store = resource_store
+        self.backend = backend
+        self.settings = settings
+
+    def record(
+        self,
+        *,
+        category: str,
+        severity: str,
+        fingerprint: str,
+        summary: str,
+        redacted_context: dict[str, Any] | None = None,
+    ) -> AnomalyRecord:
+        normalized_context = dict(redact_context(redacted_context or {}))
+        environment = _environment_name(self.settings)
+        now = utc_now_iso()
+        with self.backend.session_scope(commit=True) as session:
+            self._ensure_templates(session)
+            existing = self._find_existing(
+                session,
+                category=category,
+                severity=severity,
+                fingerprint=fingerprint,
+                environment=environment,
+            )
+            if existing is None:
+                instance = self.backend.create_instance(
+                    session,
+                    template_code=ANOMALY_TEMPLATE,
+                    name=summary[:120] or "Ursa anomaly",
+                    json_addl={
+                        "service": "ursa",
+                        "environment": environment,
+                        "category": category,
+                        "severity": severity,
+                        "fingerprint": fingerprint,
+                        "summary": summary,
+                        "first_seen_at": now,
+                        "last_seen_at": now,
+                        "occurrence_count": 1,
+                        "redacted_context": normalized_context,
+                    },
+                    bstatus="active",
+                )
+            else:
+                payload = dict(getattr(existing, "json_addl", {}) or {})
+                payload.update(
+                    {
+                        "service": "ursa",
+                        "environment": environment,
+                        "category": category,
+                        "severity": severity,
+                        "fingerprint": fingerprint,
+                        "summary": summary,
+                        "first_seen_at": str(payload.get("first_seen_at") or now),
+                        "last_seen_at": now,
+                        "occurrence_count": int(payload.get("occurrence_count") or 0) + 1,
+                        "redacted_context": normalized_context,
+                    }
+                )
+                existing.json_addl = payload
+                if hasattr(existing, "modified_dt"):
+                    existing.modified_dt = _utcnow()
+                if hasattr(session, "flush"):
+                    session.flush()
+                instance = existing
+        return self._to_record(instance)
+
+    def list(self, *, limit: int = 100) -> list[AnomalyRecord]:
+        with self.backend.session_scope(commit=False) as session:
+            rows = [
+                self._to_record(item)
+                for item in self.backend.list_instances_by_template(
+                    session,
+                    template_code=ANOMALY_TEMPLATE,
+                    limit=limit,
+                )
+            ]
+        rows.sort(key=lambda item: item.last_seen_at, reverse=True)
+        return rows
+
+    def get(self, anomaly_id: str) -> AnomalyRecord | None:
+        with self.backend.session_scope(commit=False) as session:
+            instance = self.backend.find_instance_by_euid(
+                session,
+                template_code=ANOMALY_TEMPLATE,
+                value=anomaly_id,
+            )
+            if instance is None:
+                return None
+            return self._to_record(instance)
+
+    def record_db_probe_failure(self, *, detail: str, latency_ms: float) -> AnomalyRecord:
+        return self.record(
+            category="database",
+            severity="error",
+            fingerprint=_fingerprint(detail or "database-probe-failure"),
+            summary="Ursa database probe failed",
+            redacted_context={
+                "detail": str(detail or ""),
+                "latency_ms": round(float(latency_ms), 3),
+            },
+        )
+
+    def _ensure_templates(self, session: Any) -> None:
+        ensure_templates = getattr(self.backend, "ensure_templates", None)
+        if callable(ensure_templates):
+            if callable(seed_ursa_templates):
+                seed_ursa_templates(session)
+            ensure_templates(session)
+
+    def _find_existing(
+        self,
+        session: Any,
+        *,
+        category: str,
+        severity: str,
+        fingerprint: str,
+        environment: str,
+    ) -> Any | None:
+        matches = self.backend.list_instances_by_property(
+            session,
+            template_code=ANOMALY_TEMPLATE,
+            key="fingerprint",
+            value=fingerprint,
+            limit=100,
+        )
+        for instance in matches:
+            payload = from_json_addl(instance)
+            if (
+                str(payload.get("category") or "") == category
+                and str(payload.get("severity") or "") == severity
+                and str(payload.get("environment") or "") == environment
+            ):
+                return instance
+        return None
+
+    def _to_record(self, instance: Any) -> AnomalyRecord:
+        payload = from_json_addl(instance)
+        return AnomalyRecord(
+            id=str(getattr(instance, "euid", "") or ""),
+            service=str(payload.get("service") or "ursa"),
+            environment=str(payload.get("environment") or _environment_name(self.settings)),
+            category=str(payload.get("category") or "unknown"),
+            severity=str(payload.get("severity") or "unknown"),
+            fingerprint=str(payload.get("fingerprint") or ""),
+            summary=str(payload.get("summary") or getattr(instance, "name", "") or ""),
+            first_seen_at=str(payload.get("first_seen_at") or utc_now_iso()),
+            last_seen_at=str(payload.get("last_seen_at") or payload.get("first_seen_at") or utc_now_iso()),
+            occurrence_count=int(payload.get("occurrence_count") or 0),
+            redacted_context=dict(payload.get("redacted_context") or {}),
+            source_view_url=f"/admin/anomalies/{getattr(instance, 'euid', '')}",
+        )
+
+
+def open_anomaly_repository(
+    *,
+    resource_store: ResourceStore | None,
+    settings: Settings,
+    backend: Any | None = None,
+) -> AnomalyRepository:
+    resolved_backend = backend or getattr(resource_store, "backend", None)
+    if resolved_backend is None:
+        raise RuntimeError("Anomaly backend is not configured")
+    return AnomalyRepository(
+        backend=resolved_backend,
+        resource_store=resource_store,
+        settings=settings,
+    )

--- a/daylib_ursa/gui/templates/admin_anomalies.html
+++ b/daylib_ursa/gui/templates/admin_anomalies.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block content %}
+<section class="page-header">
+    <div class="container">
+        <h1>Anomalies</h1>
+        <p>Redacted local anomaly records persisted by this Ursa instance.</p>
+    </div>
+</section>
+
+<section class="section">
+    <div class="container">
+        <div class="card">
+            <h2>Recorded Anomalies</h2>
+            {% if anomalies %}
+            <ul>
+                {% for item in anomalies %}
+                <li>
+                    <a href="/admin/anomalies/{{ item.id }}">{{ item.summary }}</a>
+                    <span>({{ item.category }} / {{ item.severity }} / {{ item.environment }})</span>
+                </li>
+                {% endfor %}
+            </ul>
+            {% else %}
+            <p>No anomalies recorded.</p>
+            {% endif %}
+        </div>
+    </div>
+</section>
+
+{% if anomaly %}
+<section class="section">
+    <div class="container">
+        <div class="card">
+            <h2>Anomaly Detail</h2>
+            <p><strong>{{ anomaly.summary }}</strong></p>
+            <pre>{{ anomaly.__dict__ | tojson(indent=2) }}</pre>
+        </div>
+    </div>
+</section>
+{% endif %}
+{% endblock %}

--- a/daylib_ursa/gui/templates/base.html
+++ b/daylib_ursa/gui/templates/base.html
@@ -87,6 +87,7 @@
                     {% if actor.is_admin %}
                     <li><a href="/admin/tokens" class="secondary-link {% if secondary_page == 'admin_tokens' %}active{% endif %}">Admin Tokens</a></li>
                     <li><a href="/admin/clients" class="secondary-link {% if secondary_page == 'admin_clients' %}active{% endif %}">Client Registrations</a></li>
+                    <li><a href="/admin/anomalies" class="secondary-link {% if secondary_page == 'admin_anomalies' %}active{% endif %}">Anomalies</a></li>
                     <li><a href="/admin/observability" class="secondary-link {% if secondary_page == 'admin_observability' %}active{% endif %}">Observability</a></li>
                     {% endif %}
                 </ul>

--- a/daylib_ursa/gui_app.py
+++ b/daylib_ursa/gui_app.py
@@ -13,6 +13,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from daylib_ursa import __version__
+from daylib_ursa.anomalies import open_anomaly_repository
 from daylib_ursa.auth import (
     AuthError,
     CurrentUser,
@@ -152,6 +153,18 @@ def mount_gui(app: FastAPI) -> None:
         if store is None:
             raise HTTPException(status_code=503, detail="Observability store is not configured")
         return store
+
+    def _anomaly_repository():
+        resources = _resource_store()
+        token_service = _token_service()
+        backend = getattr(resources, "backend", None) or getattr(token_service, "backend", None)
+        if backend is None:
+            raise HTTPException(status_code=503, detail="Anomaly repository is not configured")
+        return open_anomaly_repository(
+            resource_store=resources,
+            settings=app.state.settings,
+            backend=backend,
+        )
 
     def _render_page(
         request: Request,
@@ -1121,4 +1134,40 @@ def mount_gui(app: FastAPI) -> None:
             secondary_page="admin_observability",
             admin_only=True,
             context=context,
+        )
+
+    @app.get("/admin/anomalies", response_class=HTMLResponse)
+    async def admin_anomalies_page(request: Request):
+        repository = _anomaly_repository()
+        anomalies = repository.list()
+        return _render_page(
+            request,
+            template_name="admin_anomalies.html",
+            page_title="Anomalies",
+            active_page="tools",
+            secondary_page="admin_anomalies",
+            admin_only=True,
+            context={
+                "anomalies": anomalies,
+                "anomaly": None,
+            },
+        )
+
+    @app.get("/admin/anomalies/{anomaly_id}", response_class=HTMLResponse)
+    async def admin_anomaly_detail_page(anomaly_id: str, request: Request):
+        repository = _anomaly_repository()
+        anomaly = repository.get(anomaly_id)
+        if anomaly is None:
+            raise HTTPException(status_code=404, detail="Anomaly not found")
+        return _render_page(
+            request,
+            template_name="admin_anomalies.html",
+            page_title="Anomalies",
+            active_page="tools",
+            secondary_page="admin_anomalies",
+            admin_only=True,
+            context={
+                "anomalies": repository.list(limit=25),
+                "anomaly": anomaly,
+            },
         )

--- a/daylib_ursa/observability.py
+++ b/daylib_ursa/observability.py
@@ -201,11 +201,18 @@ class UrsaObservabilityStore:
                 {"path": "/api_health", "auth": "operator_or_service_token", "kind": "api_rollup"},
                 {"path": "/endpoint_health", "auth": "operator_or_service_token", "kind": "endpoint_rollup"},
                 {"path": "/db_health", "auth": "operator_or_service_token", "kind": "database"},
+                {"path": "/api/anomalies", "auth": "operator_or_service_token", "kind": "anomaly_list"},
+                {
+                    "path": "/api/anomalies/{anomaly_id}",
+                    "auth": "operator_or_service_token",
+                    "kind": "anomaly_detail",
+                },
                 {"path": "/my_health", "auth": "authenticated_self", "kind": "self"},
                 {"path": "/auth_health", "auth": "operator_or_service_token", "kind": "auth"},
             ],
             "extensions": [
                 "ursa.admin_observability_ui",
+                "ursa.anomalies_v1",
             ],
             "observed_at": self._started_at,
         }

--- a/daylib_ursa/tapdb_graph/backend.py
+++ b/daylib_ursa/tapdb_graph/backend.py
@@ -44,6 +44,7 @@ URSA_TEMPLATE_DEFINITIONS: list[TemplateSpec] = [
     TemplateSpec("workflow/cluster/ephemeral-job/1.0/"),
     TemplateSpec("action/cluster/ephemeral-job-revision/1.0/"),
     TemplateSpec("action/cluster/ephemeral-job-event/1.0/"),
+    TemplateSpec("ops/anomaly/local-record/1.0/"),
 ]
 
 TEMPLATE_DEFINITIONS = URSA_TEMPLATE_DEFINITIONS

--- a/daylib_ursa/workset_api.py
+++ b/daylib_ursa/workset_api.py
@@ -45,6 +45,7 @@ from daylib_ursa.analysis_store import (
     AnalysisStore,
     ReviewState,
 )
+from daylib_ursa.anomalies import open_anomaly_repository
 from daylib_ursa.atlas_result_client import (
     AtlasResultArtifact,
     AtlasResultClient,
@@ -1091,6 +1092,18 @@ def create_app(
     )
     app.state.observability_cleanup = []
 
+    def _anomaly_repository():
+        resource_store = getattr(app.state, "resource_store", None)
+        token_service = getattr(app.state, "token_service", None)
+        backend = getattr(resource_store, "backend", None) or getattr(token_service, "backend", None)
+        if resource_store is None or backend is None:
+            raise HTTPException(status_code=503, detail="Anomaly repository is not configured")
+        return open_anomaly_repository(
+            resource_store=resource_store,
+            settings=settings,
+            backend=backend,
+        )
+
     def _extract_sqlalchemy_engine(candidate: Any) -> Any | None:
         backend = getattr(candidate, "backend", None)
         if backend is None:
@@ -1762,6 +1775,12 @@ def create_app(
         _ = actor
         _database_probe()
         projection, rollup = app.state.observability.db_health()
+        if str(rollup.get("status") or "") == "error":
+            latest_probe = dict(rollup.get("latest") or {})
+            _anomaly_repository().record_db_probe_failure(
+                detail=str(latest_probe.get("detail") or "database probe failed"),
+                latency_ms=float(latest_probe.get("latency_ms") or 0.0),
+            )
         return build_db_health_payload(
             request,
             settings=settings,
@@ -1769,6 +1788,36 @@ def create_app(
             projection=projection,
             db_health=rollup,
         )
+
+    @app.get("/api/anomalies", tags=["anomalies"])
+    async def list_anomalies(actor: RequireObservability) -> dict[str, Any]:
+        _ = actor
+        items = [item.__dict__ for item in _anomaly_repository().list()]
+        observed_at = str(items[0].get("last_seen_at") or "") if items else ""
+        projection = app.state.observability.projection(observed_at=observed_at or None)
+        return {
+            "service": "ursa",
+            "contract_version": "v3",
+            "observed_at": projection.observed_at,
+            "projection": projection.model_dump(),
+            "count": len(items),
+            "items": items,
+        }
+
+    @app.get("/api/anomalies/{anomaly_id}", tags=["anomalies"])
+    async def get_anomaly(anomaly_id: str, actor: RequireObservability) -> dict[str, Any]:
+        _ = actor
+        item = _anomaly_repository().get(anomaly_id)
+        if item is None:
+            raise HTTPException(status_code=404, detail="Anomaly not found")
+        projection = app.state.observability.projection(observed_at=item.last_seen_at)
+        return {
+            "service": "ursa",
+            "contract_version": "v3",
+            "observed_at": projection.observed_at,
+            "projection": projection.model_dump(),
+            "item": item.__dict__,
+        }
 
     @app.get("/my_health", tags=["observability"])
     async def my_health(actor: RequireAuth, request: Request) -> dict[str, Any]:

--- a/tests/test_anomalies.py
+++ b/tests/test_anomalies.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from daylib_ursa.anomalies import open_anomaly_repository
+from tests.test_admin_gui_and_cluster_routes import _create_test_app
+
+
+def test_anomaly_repository_persists_and_redacts_records() -> None:
+    app, _resources = _create_test_app(admin=True)
+    repository = open_anomaly_repository(
+        resource_store=app.state.resource_store,
+        settings=app.state.settings,
+        backend=app.state.token_service.backend,
+    )
+
+    first = repository.record(
+        category="database",
+        severity="error",
+        fingerprint="db-probe-failed",
+        summary="Database probe failed",
+        redacted_context={
+            "token": "secret-token",
+            "sql": "SELECT secret FROM patient",
+            "nested": {"password": "secret"},
+        },
+    )
+    second = repository.record(
+        category="database",
+        severity="error",
+        fingerprint="db-probe-failed",
+        summary="Database probe failed again",
+        redacted_context={"authorization": "Bearer xyz"},
+    )
+
+    assert first.id == second.id
+    assert second.occurrence_count == 2
+    assert second.redacted_context["authorization"] == "[redacted]"
+
+
+def test_anomaly_api_routes_return_records_for_observability_auth() -> None:
+    app, _resources = _create_test_app(admin=True)
+    repository = open_anomaly_repository(
+        resource_store=app.state.resource_store,
+        settings=app.state.settings,
+        backend=app.state.token_service.backend,
+    )
+    created = repository.record(
+        category="database",
+        severity="error",
+        fingerprint="db-probe-failed",
+        summary="Database probe failed",
+        redacted_context={"token": "secret-token"},
+    )
+    headers = {"Authorization": f"Bearer {app.state.api_key}"}
+
+    with TestClient(app) as client:
+        list_response = client.get("/api/anomalies", headers=headers)
+        detail_response = client.get(f"/api/anomalies/{created.id}", headers=headers)
+        missing_response = client.get("/api/anomalies/ANM-DOES-NOT-EXIST", headers=headers)
+
+    assert list_response.status_code == 200
+    list_payload = list_response.json()
+    assert list_payload["service"] == "ursa"
+    assert list_payload["count"] == 1
+    assert list_payload["items"][0]["id"] == created.id
+    assert list_payload["items"][0]["redacted_context"]["token"] == "[redacted]"
+
+    assert detail_response.status_code == 200
+    assert detail_response.json()["item"]["id"] == created.id
+    assert missing_response.status_code == 404
+
+
+def test_obs_services_advertises_anomaly_capability() -> None:
+    app, _resources = _create_test_app(admin=True)
+    headers = {"Authorization": f"Bearer {app.state.api_key}"}
+
+    with TestClient(app) as client:
+        response = client.get("/obs_services", headers=headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+    endpoints = {item["path"]: item for item in payload["endpoints"]}
+    assert endpoints["/api/anomalies"]["kind"] == "anomaly_list"
+    assert endpoints["/api/anomalies/{anomaly_id}"]["kind"] == "anomaly_detail"
+    assert "ursa.anomalies_v1" in payload["extensions"]
+
+
+def test_admin_anomalies_page_requires_session_and_renders() -> None:
+    app, _resources = _create_test_app(admin=True)
+    repository = open_anomaly_repository(
+        resource_store=app.state.resource_store,
+        settings=app.state.settings,
+        backend=app.state.token_service.backend,
+    )
+    created = repository.record(
+        category="database",
+        severity="error",
+        fingerprint="db-probe-failed",
+        summary="Database probe failed",
+        redacted_context={"token": "secret-token"},
+    )
+
+    with TestClient(app) as client:
+        redirect = client.get("/admin/anomalies", follow_redirects=False)
+        client.post(
+            "/login",
+            data={"access_token": "atlas-token", "next_path": "/admin/anomalies"},
+            follow_redirects=False,
+        )
+        list_response = client.get("/admin/anomalies")
+        detail_response = client.get(f"/admin/anomalies/{created.id}")
+
+    assert redirect.status_code == 303
+    assert list_response.status_code == 200
+    assert "Anomalies" in list_response.text
+    assert created.summary in list_response.text
+    assert detail_response.status_code == 200
+    assert created.id in detail_response.text

--- a/tests/test_observability_contract.py
+++ b/tests/test_observability_contract.py
@@ -121,6 +121,11 @@ def test_obs_services_advertises_canonical_capabilities() -> None:
         "/api_health": {"auth": "operator_or_service_token", "kind": "api_rollup"},
         "/endpoint_health": {"auth": "operator_or_service_token", "kind": "endpoint_rollup"},
         "/db_health": {"auth": "operator_or_service_token", "kind": "database"},
+        "/api/anomalies": {"auth": "operator_or_service_token", "kind": "anomaly_list"},
+        "/api/anomalies/{anomaly_id}": {
+            "auth": "operator_or_service_token",
+            "kind": "anomaly_detail",
+        },
         "/my_health": {"auth": "authenticated_self", "kind": "self"},
         "/auth_health": {"auth": "operator_or_service_token", "kind": "auth"},
     }


### PR DESCRIPTION
## Summary
- add TapDB-backed Ursa anomaly persistence and authenticated read-only anomaly APIs
- add admin anomaly views and advertise anomaly support through `/obs_services`
- keep existing health endpoints and TapDB admin GUI exposure unchanged

## Testing
- pytest tests/test_anomalies.py tests/test_observability_contract.py -q