### PR TITLE
Release daylily-ursa 0.2.19

### DIFF
--- a/daylib_ursa/workset_api.py
+++ b/daylib_ursa/workset_api.py
@@ -1010,6 +1010,7 @@ def create_app(
     user_directory: CognitoUserDirectoryService | None = None,
     settings: Settings | None = None,
     require_api_key: bool | None = None,
+    s3_client: Any | None = None,
 ) -> FastAPI:
     if settings is None:
         settings = get_settings()
@@ -1031,7 +1032,7 @@ def create_app(
     app.state.atlas_client = atlas_client
     app.state.dewey_client = dewey_client
     app.state.settings = settings
-    app.state.s3_client = RegionAwareS3Client(
+    app.state.s3_client = s3_client or RegionAwareS3Client(
         default_region=settings.get_effective_region(),
         profile=settings.aws_profile,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,9 @@ dependencies = [
     "sqlalchemy>=2.0.0",
     "cli-core-yo>=0.3.0",
     # Cognito auth library
-    "daylily-cognito==0.1.30",
+    "daylily-cognito==0.1.31",
     # TapDB graph persistence
-    "daylily-tapdb==3.0.9",
+    "daylily-tapdb==3.0.10",
     "fastapi>=0.104.0",
     "uvicorn[standard]>=0.24.0",
     "pydantic>=2.0.0",

--- a/tests/test_tapdb_mount.py
+++ b/tests/test_tapdb_mount.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-from unittest.mock import patch
 
 import pytest
 from fastapi import FastAPI
@@ -36,6 +35,10 @@ class DummyBloomClient:
         raise RuntimeError("not used")
 
 
+class DummyS3Client:
+    pass
+
+
 def _fake_tapdb_app() -> FastAPI:
     app = FastAPI()
 
@@ -65,8 +68,12 @@ def test_mounted_route_exists_and_key_can_access(monkeypatch, tmp_path):
     monkeypatch.setattr("daylib_ursa.tapdb_mount._load_tapdb_admin_app", lambda: _fake_tapdb_app())
 
     settings = _settings(mount_enabled=True)
-    with patch("daylib_ursa.workset_api.RegionAwareS3Client", return_value=object()):
-        app = create_app(DummyStore(), bloom_client=DummyBloomClient(), settings=settings)
+    app = create_app(
+        DummyStore(),
+        bloom_client=DummyBloomClient(),
+        settings=settings,
+        s3_client=DummyS3Client(),
+    )
 
     assert any(getattr(route, "path", None) == "/admin/tapdb" for route in app.routes)
 
@@ -81,12 +88,12 @@ def test_mounted_route_denies_missing_api_key(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr("daylib_ursa.tapdb_mount._load_tapdb_admin_app", lambda: _fake_tapdb_app())
 
-    with patch("daylib_ursa.workset_api.RegionAwareS3Client", return_value=object()):
-        app = create_app(
-            DummyStore(),
-            bloom_client=DummyBloomClient(),
-            settings=_settings(mount_enabled=True),
-        )
+    app = create_app(
+        DummyStore(),
+        bloom_client=DummyBloomClient(),
+        settings=_settings(mount_enabled=True),
+        s3_client=DummyS3Client(),
+    )
 
     with TestClient(app) as client:
         response = client.get("/admin/tapdb/")
@@ -99,12 +106,12 @@ def test_mounted_route_denies_wrong_api_key(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr("daylib_ursa.tapdb_mount._load_tapdb_admin_app", lambda: _fake_tapdb_app())
 
-    with patch("daylib_ursa.workset_api.RegionAwareS3Client", return_value=object()):
-        app = create_app(
-            DummyStore(),
-            bloom_client=DummyBloomClient(),
-            settings=_settings(mount_enabled=True),
-        )
+    app = create_app(
+        DummyStore(),
+        bloom_client=DummyBloomClient(),
+        settings=_settings(mount_enabled=True),
+        s3_client=DummyS3Client(),
+    )
 
     with TestClient(app) as client:
         response = client.get("/admin/tapdb/", headers={"X-API-Key": "wrong-key"})
@@ -125,12 +132,12 @@ def test_mounted_mode_forces_tapdb_local_auth_bypass(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setattr("daylib_ursa.tapdb_mount._load_tapdb_admin_app", _loader)
 
-    with patch("daylib_ursa.workset_api.RegionAwareS3Client", return_value=object()):
-        app = create_app(
-            DummyStore(),
-            bloom_client=DummyBloomClient(),
-            settings=_settings(mount_enabled=True),
-        )
+    app = create_app(
+        DummyStore(),
+        bloom_client=DummyBloomClient(),
+        settings=_settings(mount_enabled=True),
+        s3_client=DummyS3Client(),
+    )
 
     with TestClient(app) as client:
         response = client.get("/admin/tapdb/", headers={"X-API-Key": "test-key"})
@@ -151,13 +158,13 @@ def test_mount_enabled_fails_fast_when_tapdb_import_fails(monkeypatch, tmp_path)
 
     monkeypatch.setattr("daylib_ursa.tapdb_mount._load_tapdb_admin_app", _boom)
 
-    with patch("daylib_ursa.workset_api.RegionAwareS3Client", return_value=object()):
-        with pytest.raises(RuntimeError, match="Failed to import TapDB admin app"):
-            create_app(
-                DummyStore(),
-                bloom_client=DummyBloomClient(),
-                settings=_settings(mount_enabled=True),
-            )
+    with pytest.raises(RuntimeError, match="Failed to import TapDB admin app"):
+        create_app(
+            DummyStore(),
+            bloom_client=DummyBloomClient(),
+            settings=_settings(mount_enabled=True),
+            s3_client=DummyS3Client(),
+        )
 
 
 def test_mount_disabled_skips_tapdb_import(monkeypatch, tmp_path):
@@ -167,10 +174,10 @@ def test_mount_disabled_skips_tapdb_import(monkeypatch, tmp_path):
         raise ModuleNotFoundError("admin.main")
 
     monkeypatch.setattr("daylib_ursa.tapdb_mount._load_tapdb_admin_app", _boom)
-    with patch("daylib_ursa.workset_api.RegionAwareS3Client", return_value=object()):
-        app = create_app(
-            DummyStore(),
-            bloom_client=DummyBloomClient(),
-            settings=_settings(mount_enabled=False),
-        )
+    app = create_app(
+        DummyStore(),
+        bloom_client=DummyBloomClient(),
+        settings=_settings(mount_enabled=False),
+        s3_client=DummyS3Client(),
+    )
     assert all(getattr(route, "path", None) != "/admin/tapdb" for route in app.routes)

--- a/tests/test_user_tokens_api.py
+++ b/tests/test_user_tokens_api.py
@@ -144,6 +144,10 @@ class DummyAnalysisStore:
         return []
 
 
+class DummyS3Client:
+    pass
+
+
 def _settings() -> Settings:
     return Settings(
         cors_origins="*",
@@ -275,6 +279,7 @@ def test_user_routes_reject_shared_api_key_and_accept_ursa_bearer_tokens() -> No
         resource_store=DummyResourceStore(),
         token_service=service,
         settings=_settings(),
+        s3_client=DummyS3Client(),
     )
 
     with TestClient(app) as client:
@@ -321,6 +326,7 @@ def test_user_token_routes_list_usage_and_revoke() -> None:
         resource_store=DummyResourceStore(),
         token_service=service,
         settings=_settings(),
+        s3_client=DummyS3Client(),
     )
 
     with TestClient(app) as client:

--- a/tests/test_worksets_api.py
+++ b/tests/test_worksets_api.py
@@ -376,6 +376,7 @@ def _create_test_app(
         resource_store=resource_store or MemoryResourceStore(),
         dewey_client=dewey_client,
         settings=_settings(),
+        s3_client=DummyS3Client(),
     )
     app.state.cluster_service = DummyClusterService()
     return app


### PR DESCRIPTION
## Summary\n- inject test S3 clients so the suite does not depend on local AWS profiles\n- bump daylily-cognito to 0.1.31\n- bump daylily-tapdb to 3.0.10\n\n## Testing\n- full pytest suite already green in local validation