### PR TITLE
Fix Ursa auth callback and YAML config seeding

### DIFF
--- a/daylib_ursa/auth/dependencies.py
+++ b/daylib_ursa/auth/dependencies.py
@@ -305,7 +305,12 @@ class CognitoAuthProvider:
     def configured(self) -> bool:
         return bool(self.user_pool_id and self.app_client_id and self.region)
 
-    def _verify_id_token_claims(self, token: str) -> dict[str, Any]:
+    def _verify_id_token_claims(
+        self,
+        token: str,
+        *,
+        access_token: str | None = None,
+    ) -> dict[str, Any]:
         try:
             from jose import JWTError, jwt
         except ImportError as exc:  # pragma: no cover - environment issue
@@ -335,6 +340,7 @@ class CognitoAuthProvider:
                     "verify_aud": False,
                 },
                 issuer=issuer,
+                access_token=(str(access_token or "").strip() or None),
             )
         except JWTError as exc:
             raise AuthError("Invalid authentication token") from exc
@@ -344,7 +350,12 @@ class CognitoAuthProvider:
             raise AuthError("Invalid token audience")
         return claims
 
-    def resolve_access_token(self, access_token: str) -> CurrentUser:
+    def resolve_access_token(
+        self,
+        access_token: str,
+        *,
+        paired_access_token: str | None = None,
+    ) -> CurrentUser:
         token = str(access_token or "").strip()
         if not token:
             raise AuthError("Bearer token is required")
@@ -353,7 +364,10 @@ class CognitoAuthProvider:
         try:
             unverified_claims = decode_jwt_unverified(token)
             if str(unverified_claims.get("token_use") or "").strip().lower() == "id":
-                claims = self._verify_id_token_claims(token)
+                claims = self._verify_id_token_claims(
+                    token,
+                    access_token=paired_access_token,
+                )
             else:
                 claims = verify_jwt_claims(
                     token,

--- a/daylib_ursa/config.py
+++ b/daylib_ursa/config.py
@@ -33,6 +33,9 @@ def _yaml_seed_from_ursa_config() -> dict[str, object]:
         "aws_profile": cfg.aws_profile,
         "ursa_portal_default_customer_id": cfg.ursa_portal_default_customer_id,
         "cognito_group_role_map": cfg.cognito_group_role_map,
+        # Missing YAML allowlists should use the existing empty-string sentinel,
+        # not literal None, so downstream settings validation stays string-based.
+        "whitelist_domains": cfg.whitelist_domains or "",
         "ursa_internal_output_bucket": cfg.ursa_internal_output_bucket,
         "tapdb_client_id": cfg.tapdb_client_id,
         "tapdb_database_name": cfg.tapdb_database_name,

--- a/daylib_ursa/gui_app.py
+++ b/daylib_ursa/gui_app.py
@@ -567,13 +567,18 @@ def mount_gui(app: FastAPI) -> None:
             raise HTTPException(status_code=400, detail="Invalid oauth state")
         try:
             token_payload = _exchange_auth_code(code.strip())
-            token = str(token_payload.get("id_token") or token_payload.get("access_token") or "").strip()
+            id_token = str(token_payload.get("id_token") or "").strip()
+            access_token = str(token_payload.get("access_token") or "").strip()
+            token = id_token or access_token
             if not token:
                 raise AuthError("Cognito token response missing id_token or access_token")
             auth_provider = getattr(app.state, "auth_provider", None)
             if auth_provider is None:
                 raise AuthError("Authentication provider is not configured")
-            actor = auth_provider.resolve_access_token(token)
+            actor = auth_provider.resolve_access_token(
+                token,
+                paired_access_token=access_token or None,
+            )
         except AuthError as exc:
             request.session.pop("ursa_oauth_state", None)
             request.session.pop("ursa_post_auth_redirect", None)

--- a/tests/test_auth_dependencies.py
+++ b/tests/test_auth_dependencies.py
@@ -34,7 +34,7 @@ def test_cognito_auth_provider_accepts_id_token_claims(monkeypatch) -> None:
     monkeypatch.setattr(
         auth_dependencies.CognitoAuthProvider,
         "_verify_id_token_claims",
-        lambda self, _token: {
+        lambda self, _token, access_token=None: {
             "sub": "user-123",
             "email": "ursa@example.com",
             "aud": "client-123",
@@ -53,6 +53,52 @@ def test_cognito_auth_provider_accepts_id_token_claims(monkeypatch) -> None:
 
     assert user.tenant_id == uuid.UUID("00000000-0000-0000-0000-000000000001")
     assert user.roles == ["ADMIN"]
+
+
+def test_cognito_auth_provider_passes_paired_access_token_for_id_token_at_hash(monkeypatch) -> None:
+    from jose import jwt
+
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        auth_dependencies,
+        "decode_jwt_unverified",
+        lambda _token: {"token_use": "id"},
+    )
+    monkeypatch.setattr(jwt, "get_unverified_header", lambda _token: {"kid": "kid-123"})
+
+    def _decode(token, key, algorithms=None, options=None, audience=None, issuer=None, subject=None, access_token=None):
+        captured["token"] = token
+        captured["key"] = key
+        captured["algorithms"] = algorithms
+        captured["issuer"] = issuer
+        captured["access_token"] = access_token
+        return {
+            "sub": "user-123",
+            "email": "ursa@example.com",
+            "aud": "client-123",
+            "custom:customer_id": "00000000-0000-0000-0000-000000000001",
+            "cognito:groups": ["ursa-admin"],
+        }
+
+    monkeypatch.setattr(jwt, "decode", _decode)
+
+    provider = auth_dependencies.CognitoAuthProvider(
+        user_pool_id="pool-123",
+        app_client_id="client-123",
+        region="us-west-2",
+    )
+    provider._jwks_cache = type("_Cache", (), {"get_key": lambda self, kid: f"key-for-{kid}"})()
+
+    user = provider.resolve_access_token(
+        "id-token-value",
+        paired_access_token="access-token-value",
+    )
+
+    assert user.roles == ["ADMIN"]
+    assert captured["token"] == "id-token-value"
+    assert captured["access_token"] == "access-token-value"
+    assert captured["issuer"] == "https://cognito-idp.us-west-2.amazonaws.com/pool-123"
 
 
 def test_claims_to_current_user_maps_external_admin_group() -> None:
@@ -77,7 +123,7 @@ def test_cognito_auth_provider_rejects_id_token_with_wrong_audience(monkeypatch)
     monkeypatch.setattr(
         auth_dependencies.CognitoAuthProvider,
         "_verify_id_token_claims",
-        lambda self, _token: (_ for _ in ()).throw(AuthError("Invalid token audience")),
+        lambda self, _token, access_token=None: (_ for _ in ()).throw(AuthError("Invalid token audience")),
     )
 
     provider = auth_dependencies.CognitoAuthProvider(

--- a/tests/test_deployment_chrome.py
+++ b/tests/test_deployment_chrome.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 from fastapi.testclient import TestClient
 
+from daylib_ursa.auth.dependencies import CognitoAuthProvider
 from daylib_ursa.auth import CurrentUser
 from daylib_ursa.config import clear_settings_cache, get_settings, get_settings_for_testing
 from daylib_ursa import gui_app
@@ -83,7 +84,7 @@ def _app_with_gui(settings):
     app.state.settings = settings
     app.state.identity_client = SimpleNamespace(resolve_access_token=lambda _token: None)
     app.state.auth_provider = SimpleNamespace(
-        resolve_access_token=lambda _token: CurrentUser(
+        resolve_access_token=lambda _token, **_kwargs: CurrentUser(
             sub="user-123",
             email="user@example.com",
             name="Ursa User",
@@ -157,6 +158,73 @@ def test_auth_callback_persists_session_and_redirects(monkeypatch):
     login_page = client.get("/login?next=/usage", follow_redirects=False)
     assert login_page.status_code == 303
     assert login_page.headers["location"] == "/usage"
+
+
+def test_auth_callback_passes_paired_access_token_for_id_token_verification(monkeypatch):
+    settings = get_settings_for_testing(
+        ursa_internal_output_bucket="ursa-internal",
+        cognito_user_pool_id="pool-123",
+        cognito_region="us-west-2",
+        cognito_domain="ursa.auth.us-west-2.amazoncognito.com",
+        cognito_app_client_id="client-123",
+        cognito_callback_url="https://localhost:8913/auth/callback",
+        cognito_logout_url="https://localhost:8913/login",
+    )
+    from fastapi import FastAPI
+    from starlette.middleware.sessions import SessionMiddleware
+    from daylib_ursa.auth import dependencies as auth_dependencies
+
+    app = FastAPI()
+    app.add_middleware(SessionMiddleware, secret_key="test-secret")
+    app.state.settings = settings
+    app.state.identity_client = SimpleNamespace(resolve_access_token=lambda _token: None)
+    app.state.auth_provider = CognitoAuthProvider(
+        user_pool_id="pool-123",
+        app_client_id="client-123",
+        region="us-west-2",
+    )
+    mount_gui(app)
+    client = TestClient(app)
+
+    monkeypatch.setattr(gui_app.secrets, "token_urlsafe", lambda _n: "state-123")
+    monkeypatch.setattr(gui_app, "build_authorization_url", lambda **_kwargs: "https://example.auth/login")
+    monkeypatch.setattr(
+        gui_app,
+        "exchange_authorization_code",
+        lambda **_kwargs: {
+            "id_token": "id-token-123",
+            "access_token": "access-token-456",
+        },
+    )
+    captured: dict[str, str | None] = {}
+    monkeypatch.setattr(
+        auth_dependencies,
+        "decode_jwt_unverified",
+        lambda _token: {"token_use": "id"},
+    )
+
+    def _verify_id_token_claims(self, token: str, *, access_token: str | None = None):
+        captured["token"] = token
+        captured["access_token"] = access_token
+        return {
+            "sub": "user-123",
+            "email": "user@example.com",
+            "aud": "client-123",
+            "custom:customer_id": "11111111-1111-1111-1111-111111111111",
+            "cognito:groups": ["ursa-admin"],
+        }
+
+    monkeypatch.setattr(CognitoAuthProvider, "_verify_id_token_claims", _verify_id_token_claims)
+
+    client.get("/auth/login?next=/usage", follow_redirects=False)
+    response = client.get("/auth/callback?code=auth-code&state=state-123", follow_redirects=False)
+
+    assert response.status_code == 303
+    assert response.headers["location"] == "/usage"
+    assert captured == {
+        "token": "id-token-123",
+        "access_token": "access-token-456",
+    }
 
 
 def test_favicon_route_redirects_to_svg():


### PR DESCRIPTION
## Summary
- pass the paired access token through the Hosted UI callback verification path
- normalize YAML-seeded whitelist domains so missing values keep using the empty-string sentinel
- add regression coverage for the callback at_hash path and YAML-only settings loading

## Testing
- pytest tests/test_auth_dependencies.py tests/test_deployment_chrome.py