### PR TITLE
[codex] Require explicit deploy-name activation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # WHEN INITIALIZING A NEW TERMINAL SESSION
 
 ## ALWAYS DO THIS FIRST
-source ./activate
+source ./activate <deploy-name>
 
 ## CLI Policy
 
@@ -18,7 +18,7 @@ source ./activate
 
 ## Ursa Examples
 
-- Start with `source ./activate`
+- Start with `source ./activate <deploy-name>`
 - Use `ursa server start --port 8913`
 - Use `ursa config ...` and `ursa env ...` for Ursa-owned runtime operations
 - Use `daycog ...` for Cognito lifecycle and `tapdb ...` for DB/runtime lifecycle where Ursa docs explicitly delegate to them

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Cross-system integrations are authenticated and should run over HTTPS.
 ## Local Development
 
 ```bash
-source ./activate
+source ./activate <deploy-name>
 ursa config init
 ursa server start --port 8913
 ```

--- a/activate
+++ b/activate
@@ -2,7 +2,7 @@
 # Ursa Environment Activation Script
 # ==========================================
 # This script must be SOURCED, not executed:
-#   source ./activate
+#   source ./activate <deploy-name>
 #
 # It will:
 #   1. Build the URSA conda environment from config/ursa_env.yaml if it doesn't exist
@@ -29,11 +29,19 @@ truthy_env() {
 
 sanitize_deployment_code() {
     raw_value="$1"
-    sanitized="$(printf '%s' "$raw_value" | LC_ALL=C sed -E 's/[^A-Za-z0-9._-]+/-/g; s/^-+//; s/-+$//')"
+    sanitized="$(printf '%s' "$raw_value" | LC_ALL=C sed -E 's/[^A-Za-z0-9-]+/-/g; s/^-+//; s/-+$//')"
     if [ -z "$sanitized" ]; then
         sanitized="local"
     fi
     printf '%s\n' "$sanitized"
+}
+
+validate_deploy_name() {
+    deploy_name="$1"
+    if ! [[ "$deploy_name" =~ ^[A-Za-z0-9-]{2,8}$ ]]; then
+        printf "${RED}✗${NC} %s\n" "deploy-name must match ^[A-Za-z0-9-]{2,8}$"
+        return 1
+    fi
 }
 
 ursa_config_dir_name() {
@@ -75,8 +83,19 @@ prepare_tapdb_config_path() {
     printf '%s\n' "$user_path"
 }
 
-CONDA_ENV_DEPLOYMENT_CODE="${URSA_DEPLOYMENT_CODE:-${DEPLOYMENT_CODE:-${LSMC_DEPLOYMENT_CODE:-local}}}"
-CONDA_ENV_DEPLOYMENT_CODE="$(sanitize_deployment_code "${CONDA_ENV_DEPLOYMENT_CODE}")"
+if [ "$#" -ne 1 ]; then
+    printf "Error: Ursa activation requires exactly one positional deploy-name.\n"
+    printf "Usage: source ./activate <deploy-name>\n"
+    _ursa_return_or_exit 1
+fi
+
+CONDA_ENV_DEPLOYMENT_CODE="$1"
+if ! validate_deploy_name "${CONDA_ENV_DEPLOYMENT_CODE}"; then
+    _ursa_return_or_exit 1
+fi
+export URSA_DEPLOYMENT_CODE="${CONDA_ENV_DEPLOYMENT_CODE}"
+export DEPLOYMENT_CODE="${CONDA_ENV_DEPLOYMENT_CODE}"
+export LSMC_DEPLOYMENT_CODE="${CONDA_ENV_DEPLOYMENT_CODE}"
 CONDA_ENV_NAME="${CONDA_ENV_BASE}-${CONDA_ENV_DEPLOYMENT_CODE}"
 
 log_info() {
@@ -131,7 +150,7 @@ PY
 
 if [ -n "${BASH_VERSION:-}" ] && [ "${BASH_SOURCE[0]}" = "$0" ]; then
     printf "Error: This script must be sourced, not executed.\n"
-    printf "Usage: source ./activate\n"
+    printf "Usage: source ./activate <deploy-name>\n"
     exit 1
 fi
 
@@ -344,6 +363,8 @@ activate_main() {
     fi
 
     export URSA_ROOT="${SCRIPT_DIR}"
+    export URSA_ACTIVE=1
+    export URSA_PROJECT_ROOT="${SCRIPT_DIR}"
     export TAPDB_CLIENT_ID="${TAPDB_CLIENT_ID:-local}"
     export TAPDB_DATABASE_NAME="${TAPDB_DATABASE_NAME:-ursa}"
     export TAPDB_STRICT_NAMESPACE="${TAPDB_STRICT_NAMESPACE:-1}"
@@ -424,4 +445,4 @@ activate_main() {
     unset URSA_TAPDB_REPO
 }
 
-activate_main "$@" || _ursa_return_or_exit $?
+activate_main || _ursa_return_or_exit $?

--- a/daylib_ursa/cli/__init__.py
+++ b/daylib_ursa/cli/__init__.py
@@ -139,7 +139,7 @@ spec = CliSpec(
     env=EnvSpec(
         active_env_var="URSA_ACTIVE",
         project_root_env_var="URSA_PROJECT_ROOT",
-        activate_script_name="activate",
+        activate_script_name="activate <deploy-name>",
         deactivate_script_name="ursa_deactivate",
     ),
     plugins=PluginSpec(

--- a/daylib_ursa/integrations/tapdb_runtime.py
+++ b/daylib_ursa/integrations/tapdb_runtime.py
@@ -36,7 +36,7 @@ class TapDBRuntimeError(RuntimeError):
 
 
 def _sanitize_deployment_code(value: str) -> str:
-    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", (value or "").strip())
+    cleaned = re.sub(r"[^A-Za-z0-9-]+", "-", (value or "").strip())
     cleaned = cleaned.strip("-")
     return cleaned or "local"
 

--- a/daylib_ursa/ursa_config.py
+++ b/daylib_ursa/ursa_config.py
@@ -45,7 +45,7 @@ class RegionConfig:
 
 
 def _sanitize_deployment_code(value: str) -> str:
-    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", str(value or "").strip()).strip("-")
+    cleaned = re.sub(r"[^A-Za-z0-9-]+", "-", str(value or "").strip()).strip("-")
     return cleaned or "local"
 
 

--- a/tests/test_activation_metadata.py
+++ b/tests/test_activation_metadata.py
@@ -22,7 +22,12 @@ def test_activate_uses_conda_only_bootstrap() -> None:
 
     assert 'CONDA_ENV_BASE="URSA"' in activate_script
     assert 'CONDA_ENV_NAME="${CONDA_ENV_BASE}-${CONDA_ENV_DEPLOYMENT_CODE}"' in activate_script
-    assert 'CONDA_ENV_DEPLOYMENT_CODE="${URSA_DEPLOYMENT_CODE:-${DEPLOYMENT_CODE:-${LSMC_DEPLOYMENT_CODE:-local}}}"' in activate_script
+    assert 'if [ "$#" -ne 1 ]; then' in activate_script
+    assert 'CONDA_ENV_DEPLOYMENT_CODE="$1"' in activate_script
+    assert 'if ! validate_deploy_name "${CONDA_ENV_DEPLOYMENT_CODE}"; then' in activate_script
+    assert 'export URSA_DEPLOYMENT_CODE="${CONDA_ENV_DEPLOYMENT_CODE}"' in activate_script
+    assert 'export DEPLOYMENT_CODE="${CONDA_ENV_DEPLOYMENT_CODE}"' in activate_script
+    assert 'export LSMC_DEPLOYMENT_CODE="${CONDA_ENV_DEPLOYMENT_CODE}"' in activate_script
     assert 'ENV_FILE="${SCRIPT_DIR}/config/ursa_env.yaml"' in activate_script
     assert 'conda env create -n "$CONDA_ENV_NAME" -f "$ENV_FILE"' in activate_script
     assert 'conda activate "$CONDA_ENV_NAME"' in activate_script

--- a/ursa-conformance-directive.md
+++ b/ursa-conformance-directive.md
@@ -194,7 +194,7 @@ spec = CliSpec(
     env=EnvSpec(
         active_env_var="URSA_ACTIVE",
         project_root_env_var="URSA_PROJECT_ROOT",
-        activate_script_name="activate",
+        activate_script_name="activate <deploy-name>",
         deactivate_script_name="ursa_deactivate",
     ),
     plugins=PluginSpec(


### PR DESCRIPTION
## Summary
- require `source ./activate <deploy-name>` for Ursa activation
- validate deploy names as `^[A-Za-z0-9-]{2,8}$` and keep deployment-scoped env/config paths aligned with that contract
- update CLI metadata and docs to reflect the explicit deploy-name requirement

## Validation
- `pytest tests/test_activation_metadata.py`
