### PR TITLE
[codex] Hard-cut Ursa TapDB config and UGX prefixes

### DIFF
--- a/activate
+++ b/activate
@@ -55,7 +55,6 @@ ursa_config_file_name() {
 prepare_tapdb_config_path() {
     client_id="$1"
     namespace="$2"
-    explicit_path="${URSA_TAPDB_CONFIG_PATH:-}"
     xdg_config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
     deployment_code="${URSA_DEPLOYMENT_CODE:-${DEPLOYMENT_CODE:-${LSMC_DEPLOYMENT_CODE:-local}}}"
     deployment_code="$(sanitize_deployment_code "${deployment_code}")"
@@ -64,10 +63,6 @@ prepare_tapdb_config_path() {
     user_path="${user_dir}/tapdb-config.yaml"
     repo_template="${SCRIPT_DIR}/config/tapdb-config-${namespace}.yaml"
 
-    if [ -n "$explicit_path" ]; then
-        printf '%s\n' "$explicit_path"
-        return 0
-    fi
     if [ -f "$user_path" ]; then
         chmod 600 "$user_path" 2>/dev/null || true
         printf '%s\n' "$user_path"
@@ -365,10 +360,10 @@ activate_main() {
     export URSA_ROOT="${SCRIPT_DIR}"
     export URSA_ACTIVE=1
     export URSA_PROJECT_ROOT="${SCRIPT_DIR}"
-    _URSA_TAPDB_CLIENT_ID="${URSA_TAPDB_CLIENT_ID:-local}"
-    _URSA_TAPDB_DATABASE_NAME="${URSA_TAPDB_DATABASE_NAME:-ursa}"
-    _URSA_TAPDB_ENV="${URSA_TAPDB_ENV:-dev}"
-    export URSA_TAPDB_CONFIG_PATH="$(prepare_tapdb_config_path "${_URSA_TAPDB_CLIENT_ID}" "${_URSA_TAPDB_DATABASE_NAME}")"
+    _URSA_TAPDB_CLIENT_ID="local"
+    _URSA_TAPDB_DATABASE_NAME="ursa"
+    _URSA_TAPDB_ENV="dev"
+    _URSA_RUNTIME_TAPDB_CONFIG_PATH="$(prepare_tapdb_config_path "${_URSA_TAPDB_CLIENT_ID}" "${_URSA_TAPDB_DATABASE_NAME}")"
 
     require_tool "conda env" "aws" || return 1
     require_tool "conda env" "pcluster" || return 1

--- a/config/tapdb-config-ursa.yaml
+++ b/config/tapdb-config-ursa.yaml
@@ -1,5 +1,5 @@
 meta:
-  config_version: 2
+  config_version: 3
   client_id: local
   database_name: ursa
 environments:

--- a/config/ursa-config.example.yaml
+++ b/config/ursa-config.example.yaml
@@ -32,8 +32,8 @@ regions:
 # =============================================================================
 # Ursa reads its TapDB namespace/runtime from this YAML file.
 # Bootstrap the matching namespace with:
-#   tapdb --client-id local --database-name ursa config init --env dev --db-port dev=5541 --ui-port dev=8916
-#   tapdb --client-id local --database-name ursa bootstrap local
+#   tapdb --config ~/.config/tapdb/local/ursa/tapdb-config.yaml --env dev config init --env dev --db-port dev=5541 --ui-port dev=8916
+#   tapdb --config ~/.config/tapdb/local/ursa/tapdb-config.yaml --env dev bootstrap local
 tapdb_client_id: local
 tapdb_database_name: ursa
 tapdb_env: dev

--- a/config/ursa_env.yaml
+++ b/config/ursa_env.yaml
@@ -26,9 +26,9 @@ dependencies:
       - boto3>=1.26.0
       - click==8.3.0
       - connexion==2.13.1
-      - cli-core-yo>=0.4.0
-      - daylily-cognito==0.2.0
-      - daylily-tapdb==3.1.0
+      - cli-core-yo>=0.5.0
+      - daylily-cognito==0.3.0
+      - daylily-tapdb==3.2.0
       - flask==2.2.5
       - httpx
       - itsdangerous>=2.2.0

--- a/config/workset-monitor-config.template.yaml
+++ b/config/workset-monitor-config.template.yaml
@@ -9,11 +9,9 @@
 #   # Edit my-monitor-config.yaml with your settings
 #   daylily-workset-monitor config/my-monitor-config.yaml --enable-tapdb
 #
-# For TapDB state tracking (recommended for portal UI):
-#   export TAPDB_STRICT_NAMESPACE=1
-#   export TAPDB_CLIENT_ID=local
-#   export TAPDB_DATABASE_NAME=ursa
-#   export TAPDB_ENV=dev
+# For TapDB state tracking (recommended for portal UI), prefer an explicit
+# TapDB config file and target environment:
+#   tapdb --config ~/.config/tapdb/local/ursa/tapdb-config.yaml --env dev info
 #
 #   daylily-workset-monitor config/my-monitor-config.yaml \
 #     --enable-tapdb \

--- a/config/workset-monitor-config.yaml
+++ b/config/workset-monitor-config.yaml
@@ -9,11 +9,9 @@
 #   # Edit my-monitor-config.yaml with your settings
 #   daylily-workset-monitor config/my-monitor-config.yaml --enable-tapdb
 #
-# For TapDB state tracking (recommended for portal UI):
-#   export TAPDB_STRICT_NAMESPACE=1
-#   export TAPDB_CLIENT_ID=local
-#   export TAPDB_DATABASE_NAME=ursa
-#   export TAPDB_ENV=dev
+# For TapDB state tracking (recommended for portal UI), prefer an explicit
+# TapDB config file and target environment:
+#   tapdb --config ~/.config/tapdb/local/ursa/tapdb-config.yaml --env dev info
 #
 #   daylily-workset-monitor config/my-monitor-config.yaml \
 #     --enable-tapdb \

--- a/daylib_ursa/integrations/tapdb_runtime.py
+++ b/daylib_ursa/integrations/tapdb_runtime.py
@@ -307,14 +307,14 @@ def _resolve_tapdb_config_path(
     return None
 
 
-def resolve_tapdb_cli_cwd(cwd: Path | None = None) -> Path | None:
-    base = cwd.resolve() if cwd else Path.cwd().resolve()
-    candidates = _local_tapdb_repo_candidates(base)
-    for candidate in candidates:
-        schema_file = candidate / "schema" / "tapdb_schema.sql"
-        if candidate.exists() and schema_file.exists():
-            return candidate
-    return cwd
+def _require_config_path(runtime_env: Mapping[str, str]) -> str:
+    config_path = str(runtime_env.get("config_path") or "").strip()
+    if not config_path:
+        raise TapDBRuntimeError(
+            "TapDB config path is required. Resolve it via Ursa settings and pass it explicitly "
+            "to TapDB with --config."
+        )
+    return config_path
 
 
 def export_database_url_for_target(
@@ -337,9 +337,10 @@ def export_database_url_for_target(
         tapdb_env=tapdb_env,
         config_path=config_path,
     )
+    resolved_config_path = _require_config_path(runtime_env)
     cfg = _get_tapdb_db_config_for_env(
         runtime_env["tapdb_env"],
-        config_path=runtime_env["config_path"],
+        config_path=resolved_config_path,
         client_id=runtime_env["client_id"],
         database_name=runtime_env["database_name"],
     )
@@ -367,7 +368,7 @@ def get_tapdb_bundle(
         tapdb_env=tapdb_env,
         config_path=config_path,
     )
-    resolved_config_path = runtime_env["config_path"]
+    resolved_config_path = _require_config_path(runtime_env)
     cfg = _get_tapdb_db_config_for_env(
         runtime_env["tapdb_env"],
         config_path=resolved_config_path,
@@ -422,18 +423,13 @@ def run_tapdb_cli(
         sys.executable,
         "-m",
         "daylily_tapdb.cli",
-        "--client-id",
-        runtime_env["client_id"],
-        "--database-name",
-        runtime_env["database_name"],
+        "--config",
+        _require_config_path(runtime_env),
         "--env",
         runtime_env["tapdb_env"],
     ]
-    if runtime_env["config_path"]:
-        cmd.extend(["--config", runtime_env["config_path"]])
     cmd.extend(args)
 
-    resolved_cwd = resolve_tapdb_cli_cwd(cwd)
     child_env = os.environ.copy()
     child_env["AWS_PROFILE"] = runtime_env["aws_profile"]
     child_env["AWS_REGION"] = runtime_env["aws_region"]
@@ -441,7 +437,7 @@ def run_tapdb_cli(
     child_env.setdefault("PYTHONSAFEPATH", "1")
     result = subprocess.run(
         cmd,
-        cwd=resolved_cwd,
+        cwd=cwd,
         env=child_env,
         capture_output=True,
         text=True,

--- a/daylib_ursa/tapdb_mount.py
+++ b/daylib_ursa/tapdb_mount.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hmac
 import importlib
 import logging
-import os
 from typing import Callable
 
 from fastapi import FastAPI
@@ -16,19 +15,41 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from daylib_ursa.config import Settings
 
 LOGGER = logging.getLogger("daylily.tapdb_mount")
+_URSA_TAPDB_SCOPE_USER_KEY = "ursa_tapdb_user"
 
 
-def _force_mounted_auth_bypass_env() -> None:
-    """Force TapDB into mounted mode without TapDB-local auth."""
-    os.environ["TAPDB_ADMIN_DISABLE_AUTH"] = "true"
-    os.environ["TAPDB_ADMIN_DISABLED_USER_ROLE"] = "admin"
-    os.environ["TAPDB_ADMIN_DISABLED_USER_EMAIL"] = "ursa-mounted-tapdb-admin@localhost"
-    os.environ["TAPDB_ADMIN_SHARED_AUTH"] = "false"
+def _embedded_tapdb_admin_user() -> dict[str, object]:
+    return {
+        "uid": 0,
+        "username": "ursa-mounted-tapdb-admin@localhost",
+        "email": "ursa-mounted-tapdb-admin@localhost",
+        "display_name": "Ursa Mounted TapDB Admin",
+        "role": "admin",
+        "is_active": True,
+        "require_password_change": False,
+    }
+
+
+def _configure_embedded_tapdb_auth(admin_main_module, admin_auth_module) -> None:
+    if getattr(admin_main_module, "_ursa_embedded_auth_configured", False):
+        return
+
+    async def _get_current_user(request):
+        user = request.scope.get(_URSA_TAPDB_SCOPE_USER_KEY)
+        if isinstance(user, dict):
+            return user
+        return None
+
+    admin_auth_module.get_current_user = _get_current_user
+    admin_main_module.get_current_user = _get_current_user
+    setattr(admin_main_module, "_ursa_embedded_auth_configured", True)
 
 
 def _load_tapdb_admin_app() -> ASGIApp:
     """Load the TapDB admin FastAPI app lazily."""
     module = importlib.import_module("admin.main")
+    auth_module = importlib.import_module("admin.auth")
+    _configure_embedded_tapdb_auth(module, auth_module)
     tapdb_app = getattr(module, "app", None)
     if tapdb_app is None:
         raise RuntimeError("admin.main does not export an 'app'")
@@ -51,7 +72,9 @@ class UrsaTapdbAdminGate:
             await self._deny_not_authenticated(scope, receive, send)
             return
 
-        await self._app(scope, receive, send)
+        forward_scope = dict(scope)
+        forward_scope[_URSA_TAPDB_SCOPE_USER_KEY] = _embedded_tapdb_admin_user()
+        await self._app(forward_scope, receive, send)
 
     def _is_authenticated(self, scope: Scope) -> bool:
         connection = HTTPConnection(scope)
@@ -95,7 +118,6 @@ def mount_tapdb_admin(
     if any(getattr(route, "path", None) == mount_path for route in app.routes):
         raise RuntimeError(f"Cannot mount TapDB: path already in use: {mount_path}")
 
-    _force_mounted_auth_bypass_env()
     resolved_loader = loader or _load_tapdb_admin_app
     try:
         tapdb_app = resolved_loader()

--- a/daylib_ursa/tapdb_templates.py
+++ b/daylib_ursa/tapdb_templates.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from daylily_tapdb import resolve_seed_config_dirs, seed_templates, validate_template_configs
+from daylily_tapdb import (
+    find_tapdb_core_config_dir,
+    resolve_seed_config_dirs,
+    seed_templates,
+    validate_template_configs,
+)
+from daylily_tapdb.euid import resolve_client_scoped_core_prefix
 
 
 def template_config_root() -> Path:
@@ -14,11 +20,17 @@ def template_config_root() -> Path:
 
 def seed_ursa_templates(session) -> None:
     """Load the canonical Ursa JSON template pack through TapDB."""
+    core_prefix = resolve_client_scoped_core_prefix("U")
     config_dirs = resolve_seed_config_dirs(template_config_root())
     templates, issues = validate_template_configs(config_dirs, strict=True)
     errors = [issue for issue in issues if issue.level == "error"]
     if errors:
         joined = "; ".join(issue.message for issue in errors)
         raise RuntimeError(f"Ursa template pack validation failed: {joined}")
-    seed_templates(session, templates, overwrite=True)
-
+    seed_templates(
+        session,
+        templates,
+        overwrite=True,
+        core_config_dir=find_tapdb_core_config_dir(),
+        core_instance_prefix=core_prefix,
+    )

--- a/docs/MULTI_REGION.md
+++ b/docs/MULTI_REGION.md
@@ -5,7 +5,9 @@ surface is the analysis API described in [../README.md](../README.md).
 
 Ursa can scan multiple AWS regions for ParallelCluster instances and run worksets on clusters in any configured region.
 
-TapDB persistence is Postgres-backed and configured via `TAPDB_*` strict-namespace environment variables. TapDB is not configured as per-region “tables”.
+TapDB persistence is Postgres-backed and configured via the deployment TapDB
+config file plus explicit `--config` and `--env` selection. TapDB is not
+configured as per-region “tables”.
 
 ## Configure Regions
 

--- a/docs/tapdb_mount_execplan.md
+++ b/docs/tapdb_mount_execplan.md
@@ -10,7 +10,7 @@ auth flow.
 
 1. Add a dedicated Ursa integration module to:
    - lazy load TapDB admin app (`admin.main:app`)
-   - force mounted-mode TapDB auth bypass env vars
+   - wire an explicit mounted admin identity into the embedded TapDB app
    - enforce Ursa admin session gate before forwarding requests
 2. Mount TapDB from `daylib_ursa.workset_api.create_app` after Ursa routes are
    composed.
@@ -32,5 +32,5 @@ auth flow.
 
 - Ursa starts one FastAPI app containing `/admin/tapdb`.
 - Mounted TapDB routes are inaccessible without Ursa admin session.
-- TapDB local auth flow is bypassed in mounted mode.
+- TapDB local auth flow is bypassed in mounted mode without mutating `TAPDB_ADMIN_*`.
 - Tests pass for mounted admin-only behavior and startup policy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,11 @@ dependencies = [
     "boto3>=1.26.0",
     "pyyaml>=6.0",
     "sqlalchemy>=2.0.0",
-    "cli-core-yo>=0.4.0",
+    "cli-core-yo>=0.5.0",
     # Cognito auth library
-    "daylily-cognito==0.2.0",
+    "daylily-cognito==0.3.0",
     # TapDB graph persistence
-    "daylily-tapdb==3.1.0",
+    "daylily-tapdb==3.2.0",
     "fastapi>=0.104.0",
     "uvicorn[standard]>=0.24.0",
     "pydantic>=2.0.0",

--- a/tests/test_tapdb_backend.py
+++ b/tests/test_tapdb_backend.py
@@ -111,7 +111,11 @@ def test_export_database_url_for_target_sets_runtime_environment(monkeypatch) ->
             "database": "daylily_ursa",
         },
     )
-    monkeypatch.setattr(tapdb_runtime, "_resolve_tapdb_config_path", lambda **_kwargs: None)
+    monkeypatch.setattr(
+        tapdb_runtime,
+        "_resolve_tapdb_config_path",
+        lambda **_kwargs: "/tmp/ursa-tapdb.yaml",
+    )
 
     db_url = tapdb_runtime.export_database_url_for_target(
         target="local",
@@ -154,6 +158,7 @@ def test_repo_ships_tapdb_config_template() -> None:
     payload = yaml.safe_load(template_path.read_text(encoding="utf-8"))
 
     assert template_path.is_file()
+    assert payload["meta"]["config_version"] == 3
     assert payload["meta"]["client_id"] == "local"
     assert payload["meta"]["database_name"] == "ursa"
     assert payload["environments"]["dev"]["port"] == "5588"

--- a/tests/test_tapdb_mount.py
+++ b/tests/test_tapdb_mount.py
@@ -120,17 +120,12 @@ def test_mounted_route_denies_wrong_api_key(monkeypatch, tmp_path):
     assert response.json() == {"detail": "Invalid or missing API key"}
 
 
-def test_mounted_mode_forces_tapdb_local_auth_bypass(monkeypatch, tmp_path):
-    captured: dict[str, str | None] = {}
-
-    def _loader():
-        captured["disable_auth"] = os.environ.get("TAPDB_ADMIN_DISABLE_AUTH")
-        captured["disabled_role"] = os.environ.get("TAPDB_ADMIN_DISABLED_USER_ROLE")
-        captured["shared_auth"] = os.environ.get("TAPDB_ADMIN_SHARED_AUTH")
-        return _fake_tapdb_app()
-
+def test_mounted_mode_does_not_inject_tapdb_admin_env(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setattr("daylib_ursa.tapdb_mount._load_tapdb_admin_app", _loader)
+    monkeypatch.delenv("TAPDB_ADMIN_DISABLE_AUTH", raising=False)
+    monkeypatch.delenv("TAPDB_ADMIN_DISABLED_USER_ROLE", raising=False)
+    monkeypatch.delenv("TAPDB_ADMIN_SHARED_AUTH", raising=False)
+    monkeypatch.setattr("daylib_ursa.tapdb_mount._load_tapdb_admin_app", _fake_tapdb_app)
 
     app = create_app(
         DummyStore(),
@@ -143,11 +138,9 @@ def test_mounted_mode_forces_tapdb_local_auth_bypass(monkeypatch, tmp_path):
         response = client.get("/admin/tapdb/", headers={"X-API-Key": "test-key"})
 
     assert response.status_code == 200
-    assert captured == {
-        "disable_auth": "true",
-        "disabled_role": "admin",
-        "shared_auth": "false",
-    }
+    assert "TAPDB_ADMIN_DISABLE_AUTH" not in os.environ
+    assert "TAPDB_ADMIN_DISABLED_USER_ROLE" not in os.environ
+    assert "TAPDB_ADMIN_SHARED_AUTH" not in os.environ
 
 
 def test_mount_enabled_fails_fast_when_tapdb_import_fails(monkeypatch, tmp_path):


### PR DESCRIPTION
## What changed
- remove ambient TapDB runtime config use from Ursa activation and runtime paths
- normalize Ursa-owned TapDB prefixes to UGX
- update shared-library dependency versions for the new release train

## Why
- align Ursa with the explicit TapDB config contract
- consume the new shared-library versions published earlier in the train

## Validation
- skipped in this publish run per release request