### PR TITLE
[codex] Fix activation editable validation and env tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,9 +189,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  and can be added to the global gitignore or merged into this file. However, if you prefer,
 #  you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 
@@ -222,3 +222,6 @@ ssl/
 *.crt
 *.p12
 *.pfx
+
+# Local Dayhoff conda env exports
+.dayhoff-*-conda-env.yaml

--- a/activate
+++ b/activate
@@ -178,34 +178,34 @@ unset _URSA_SCRIPT_PATH
 ENV_FILE="${SCRIPT_DIR}/environment.yaml"
 BIN_DIR="${SCRIPT_DIR}/bin"
 
-module_is_from_repo() {
-    module_name="$1"
+distribution_is_editable_from_repo() {
+    dist_name="$1"
     repo_root="$2"
-    python - "${module_name}" "${repo_root}" >/dev/null 2>&1 <<'PY'
-import importlib
-import pathlib
-import sys
+    editable_location=""
 
-module = importlib.import_module(sys.argv[1])
-repo_root = pathlib.Path(sys.argv[2]).resolve()
-module_file = getattr(module, "__file__", "")
-if not module_file:
-    raise SystemExit(1)
-module_path = pathlib.Path(module_file).resolve()
-raise SystemExit(0 if module_path == repo_root or repo_root in module_path.parents else 1)
-PY
+    editable_location="$(python -m pip show "$dist_name" 2>/dev/null | awk -F': ' '/^Editable project location:/ {print $2; exit}')"
+    [ -n "$editable_location" ] || return 1
+
+    editable_location="$(cd "$editable_location" 2>/dev/null && pwd)"
+    [ -n "$editable_location" ] || return 1
+
+    [ "$editable_location" = "$repo_root" ]
 }
 
 ensure_editable_repo() {
     label="$1"
-    module_name="$2"
+    dist_name="$2"
     repo_root="$3"
     extras="${4:-}"
     install_target=""
     if [ -z "$repo_root" ]; then
         return 0
     fi
-    if module_is_from_repo "$module_name" "$repo_root"; then
+    if [ -z "$dist_name" ]; then
+        fail_activate "Distribution name is required for local ${label} checkout validation"
+        return 1
+    fi
+    if distribution_is_editable_from_repo "$dist_name" "$repo_root"; then
         log_success "Using local ${label} checkout: ${repo_root}"
         return 0
     fi
@@ -215,11 +215,22 @@ ensure_editable_repo() {
         fail_activate "Failed to install local ${label} checkout from ${repo_root}"
         return 1
     fi
-    if ! module_is_from_repo "$module_name" "$repo_root"; then
-        fail_activate "${label} still resolves outside ${repo_root}"
+    if ! distribution_is_editable_from_repo "$dist_name" "$repo_root"; then
+        fail_activate "${label} is not installed editable from ${repo_root}"
         return 1
     fi
     log_success "Using local ${label} checkout: ${repo_root}"
+}
+
+ensure_pre_commit_hooks() {
+    if ! git -C "${SCRIPT_DIR}" rev-parse --git-dir >/dev/null 2>&1; then
+        return 0
+    fi
+    if ! (cd "${SCRIPT_DIR}" && pre-commit install --hook-type pre-commit --hook-type pre-push >/dev/null); then
+        fail_activate "Failed to install Git pre-commit hooks"
+        return 1
+    fi
+    log_success "Installed Git pre-commit and pre-push hooks"
 }
 
 activate_main() {
@@ -298,7 +309,7 @@ activate_main() {
         esac
     fi
 
-    if ! ensure_editable_repo "Ursa" "daylib_ursa" "${SCRIPT_DIR}"; then
+    if ! ensure_editable_repo "Ursa" "daylily-ursa" "${SCRIPT_DIR}"; then
         return 1
     fi
 
@@ -332,11 +343,13 @@ activate_main() {
     require_tool "conda env" "psql" || return 1
     require_tool "conda env" "node" || return 1
     require_tool "conda env" "ipython" || return 1
+    require_tool "conda env" "pre-commit" || return 1
     require_python_import "daylily_tapdb" "daylily-tapdb" || return 1
     require_python_import "daylily_cognito" "daylily-cognito" || return 1
     require_python_import "cli_core_yo" "cli-core-yo" || return 1
     require_python_import "fastapi" "fastapi" || return 1
     require_python_import "pydantic_settings" "pydantic-settings" || return 1
+    ensure_pre_commit_hooks || return 1
 
     URSA_CONFIG_FILE="${HOME}/.config/$(ursa_config_dir_name)/$(ursa_config_file_name)"
     URSA_CONFIG_EXAMPLE="${SCRIPT_DIR}/config/ursa-config.example.yaml"

--- a/environment.yaml
+++ b/environment.yaml
@@ -16,6 +16,8 @@ dependencies:
   - awscli==2.22.4
   - postgresql
   - nodejs
+  - ipython
+  - pre-commit
   - pip
   - pip:
       - boto3>=1.26.0

--- a/tests/test_activation_metadata.py
+++ b/tests/test_activation_metadata.py
@@ -33,6 +33,8 @@ def test_activate_uses_conda_only_bootstrap() -> None:
     assert (project_root / "environment.yaml").is_file()
     assert not (project_root / "config" / "ursa_env.yaml").exists()
     assert "-e ." not in environment
+    assert "\n  - ipython\n" in environment
+    assert "\n  - pre-commit\n" in environment
 
     activate_script = (Path(__file__).resolve().parents[1] / "activate").read_text(encoding="utf-8")
 
@@ -47,6 +49,8 @@ def test_activate_uses_conda_only_bootstrap() -> None:
     assert 'ENV_FILE="${SCRIPT_DIR}/environment.yaml"' in activate_script
     assert 'conda env create -n "$CONDA_ENV_NAME" -f "$ENV_FILE"' in activate_script
     assert 'conda activate "$CONDA_ENV_NAME"' in activate_script
+    assert 'require_tool "conda env" "pre-commit"' in activate_script
+    assert "pre-commit install --hook-type pre-commit --hook-type pre-push" in activate_script
     assert 'require_python_import "daylily_tapdb" "daylily-tapdb"' in activate_script
     assert 'pip install --no-deps -e "$install_target" -q' in activate_script
     assert ".venv" not in activate_script


### PR DESCRIPTION
## What changed
- replaced the activation editable-check verification with package metadata validation based on `Editable project location`, following the working Atlas pattern and avoiding cwd-sensitive import checks
- added `ipython` and `pre-commit` to the conda environment and updated activation metadata coverage accordingly
- installed git pre-commit and pre-push hooks from `activate`
- ignored machine-local `.dayhoff` conda env exports alongside the TLS ignore additions

## Why
The activation script could report `Ursa still resolves outside ...` when sourced from a shell whose current working directory was a different Ursa checkout, even if the editable install already pointed at the intended repo. The release also needed the shell tooling that activation now requires.

## Impact
- activation now validates the installed editable checkout deterministically instead of depending on Python import resolution from the caller's cwd
- the deployment-scoped conda env contains the shell tools that `activate` now enforces
- local machine-specific env exports are kept out of git

## Validation
- `source ./activate jemloc7`
- sourced `activate` successfully from both the repo cwd and `/tmp`
- `python -m pytest tests/test_activation_metadata.py -q`