### PR TITLE
chore(cli): separate test vs quality commands

### DIFF
--- a/daylib_ursa/cli/quality.py
+++ b/daylib_ursa/cli/quality.py
@@ -1,16 +1,30 @@
-"""Quality command aliases for the Ursa CLI."""
+"""Code quality commands for Ursa CLI."""
 
 from __future__ import annotations
 
+import subprocess
+import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import typer
+from rich.console import Console
 
 if TYPE_CHECKING:
     from cli_core_yo.registry import CommandRegistry
     from cli_core_yo.spec import CliSpec
 
 quality_app = typer.Typer(help="Code quality commands")
+console = Console()
+
+
+def _get_project_root() -> Path:
+    """Get the project root directory."""
+    cwd = Path.cwd()
+    for parent in [cwd] + list(cwd.parents):
+        if (parent / "pyproject.toml").exists():
+            return parent
+    return cwd
 
 
 @quality_app.command("lint")
@@ -18,9 +32,13 @@ def lint(
     fix: bool = typer.Option(False, "--fix", "-f", help="Auto-fix issues"),
 ):
     """Run the ruff linter."""
-    from daylib_ursa.cli import test as test_cmds
-
-    test_cmds.lint(fix=fix)
+    project_root = _get_project_root()
+    cmd = [sys.executable, "-m", "ruff", "check", "daylib_ursa/", "tests/"]
+    if fix:
+        cmd.append("--fix")
+    console.print("[cyan]Running linter...[/cyan]")
+    result = subprocess.run(cmd, cwd=project_root)
+    raise typer.Exit(result.returncode)
 
 
 @quality_app.command("format")
@@ -28,25 +46,48 @@ def format_code(
     check: bool = typer.Option(False, "--check", "-c", help="Check only, don't modify"),
 ):
     """Format code with ruff."""
-    from daylib_ursa.cli import test as test_cmds
-
-    test_cmds.format_code(check=check)
+    project_root = _get_project_root()
+    cmd = [sys.executable, "-m", "ruff", "format", "daylib_ursa/", "tests/"]
+    if check:
+        cmd.append("--check")
+    console.print(f"[cyan]{'Checking' if check else 'Formatting'} code...[/cyan]")
+    result = subprocess.run(cmd, cwd=project_root)
+    raise typer.Exit(result.returncode)
 
 
 @quality_app.command("typecheck")
 def typecheck():
-    """Run the type checker."""
-    from daylib_ursa.cli import test as test_cmds
-
-    test_cmds.typecheck()
+    """Run mypy type checker."""
+    project_root = _get_project_root()
+    cmd = [sys.executable, "-m", "mypy", "daylib_ursa/"]
+    console.print("[cyan]Running type checker...[/cyan]")
+    result = subprocess.run(cmd, cwd=project_root)
+    raise typer.Exit(result.returncode)
 
 
 @quality_app.command("check")
 def check():
-    """Run the standard quality bundle."""
-    from daylib_ursa.cli import test as test_cmds
-
-    test_cmds.all_checks()
+    """Run the standard quality bundle (lint + format check + typecheck)."""
+    project_root = _get_project_root()
+    checks = [
+        ("Lint", [sys.executable, "-m", "ruff", "check", "daylib_ursa/", "tests/"]),
+        ("Format", [sys.executable, "-m", "ruff", "format", "--check", "daylib_ursa/", "tests/"]),
+        ("Typecheck", [sys.executable, "-m", "mypy", "daylib_ursa/"]),
+    ]
+    failed = []
+    for name, cmd in checks:
+        console.print(f"\n[cyan]Running {name}...[/cyan]")
+        result = subprocess.run(cmd, cwd=project_root)
+        if result.returncode != 0:
+            failed.append(name)
+            console.print(f"[red]✗[/red]  {name} failed")
+        else:
+            console.print(f"[green]✓[/green]  {name} passed")
+    if failed:
+        console.print(f"\n[red]✗[/red]  {len(failed)} check(s) failed: {', '.join(failed)}")
+        raise typer.Exit(1)
+    else:
+        console.print("\n[green]✓[/green]  All quality checks passed")
 
 
 def register(registry: CommandRegistry, spec: CliSpec) -> None:

--- a/daylib_ursa/cli/test.py
+++ b/daylib_ursa/cli/test.py
@@ -1,4 +1,4 @@
-"""Testing and code quality commands for Ursa CLI."""
+"""Test execution commands for Ursa CLI."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from cli_core_yo.registry import CommandRegistry
     from cli_core_yo.spec import CliSpec
 
-test_app = typer.Typer(help="Testing and code quality commands")
+test_app = typer.Typer(help="Test execution commands")
 console = Console()
 
 
@@ -73,82 +73,19 @@ def coverage(
     raise typer.Exit(result.returncode)
 
 
-@test_app.command("lint")
-def lint(
-    fix: bool = typer.Option(False, "--fix", "-f", help="Auto-fix issues"),
-):
-    """Run ruff linter."""
-    project_root = _get_project_root()
-
-    cmd = [sys.executable, "-m", "ruff", "check", "daylib_ursa/", "tests/"]
-
-    if fix:
-        cmd.append("--fix")
-
-    console.print("[cyan]Running linter...[/cyan]")
-    result = subprocess.run(cmd, cwd=project_root)
-    raise typer.Exit(result.returncode)
-
-
-@test_app.command("format")
-def format_code(
-    check: bool = typer.Option(False, "--check", "-c", help="Check only, don't modify"),
-):
-    """Format code with ruff."""
-    project_root = _get_project_root()
-
-    cmd = [sys.executable, "-m", "ruff", "format", "daylib_ursa/", "tests/"]
-
-    if check:
-        cmd.append("--check")
-
-    console.print(f"[cyan]{'Checking' if check else 'Formatting'} code...[/cyan]")
-    result = subprocess.run(cmd, cwd=project_root)
-    raise typer.Exit(result.returncode)
-
-
-@test_app.command("typecheck")
-def typecheck():
-    """Run mypy type checker."""
-    project_root = _get_project_root()
-
-    cmd = [sys.executable, "-m", "mypy", "daylib_ursa/"]
-
-    console.print("[cyan]Running type checker...[/cyan]")
-    result = subprocess.run(cmd, cwd=project_root)
-    raise typer.Exit(result.returncode)
-
-
 @test_app.command("all")
 def all_checks():
-    """Run all quality checks (lint, format check, typecheck, tests)."""
+    """Run the full test suite with coverage."""
     project_root = _get_project_root()
 
-    checks = [
-        ("Lint", [sys.executable, "-m", "ruff", "check", "daylib_ursa/", "tests/"]),
-        ("Format", [sys.executable, "-m", "ruff", "format", "--check", "daylib_ursa/", "tests/"]),
-        ("Tests", [sys.executable, "-m", "pytest", "-q", "--tb=short"]),
-    ]
+    cmd = [sys.executable, "-m", "pytest", "-q", "--tb=short", "--cov=daylib_ursa"]
 
-    failed = []
-
-    for name, cmd in checks:
-        console.print(f"\n[cyan]Running {name}...[/cyan]")
-        result = subprocess.run(cmd, cwd=project_root)
-        if result.returncode != 0:
-            failed.append(name)
-            console.print(f"[red]✗[/red]  {name} failed")
-        else:
-            console.print(f"[green]✓[/green]  {name} passed")
-
-    if failed:
-        console.print(f"\n[red]✗[/red]  {len(failed)} check(s) failed: {', '.join(failed)}")
-        raise typer.Exit(1)
-    else:
-        console.print("\n[green]✓[/green]  All checks passed")
+    console.print("[cyan]Running full test suite...[/cyan]")
+    result = subprocess.run(cmd, cwd=project_root)
+    raise typer.Exit(result.returncode)
 
 
 def register(registry: CommandRegistry, spec: CliSpec) -> None:
     """cli-core-yo plugin: register test command group."""
     _ = spec
-    registry.add_typer_app(None, test_app, "test", "Testing and code quality")
+    registry.add_typer_app(None, test_app, "test", "Test execution commands")


### PR DESCRIPTION
CN-1 naming audit: remove lint/format/typecheck from test group, make quality group self-contained.