### PR TITLE
breaking: remove URSA_SSL env var fallback (§1.21 completion)

### DIFF
--- a/daylib_ursa/cli/server.py
+++ b/daylib_ursa/cli/server.py
@@ -152,17 +152,8 @@ def _resolve_https_cert_paths(
     key: str | None = None,
 ) -> tuple[str, str]:
     shared_dir = _shared_dayhoff_certs_dir()
-    env = dict(os.environ)
-    if not str(env.get("SSL_CERT_FILE", "")).strip():
-        legacy_cert = str(env.get("URSA_SSL_CERT_FILE", "")).strip()
-        if legacy_cert:
-            env["SSL_CERT_FILE"] = legacy_cert
-    if not str(env.get("SSL_KEY_FILE", "")).strip():
-        legacy_key = str(env.get("URSA_SSL_KEY_FILE", "")).strip()
-        if legacy_key:
-            env["SSL_KEY_FILE"] = legacy_key
-    env_cert = str(env.get("SSL_CERT_FILE", "")).strip()
-    env_key = str(env.get("SSL_KEY_FILE", "")).strip()
+    env_cert = str(os.environ.get("SSL_CERT_FILE", "")).strip()
+    env_key = str(os.environ.get("SSL_KEY_FILE", "")).strip()
     if bool(env_cert) != bool(env_key):
         console.print("[red]✗[/red]  SSL_CERT_FILE and SSL_KEY_FILE must be set together")
         raise typer.Exit(1)
@@ -170,7 +161,6 @@ def _resolve_https_cert_paths(
         resolved = resolve_https_certs(
             cert_path=cert,
             key_path=key,
-            env=env,
             shared_certs_dir=shared_dir,
             fallback_certs_dir=REPO_CERTS_DIR,
             hosts=_https_san_hosts(host),


### PR DESCRIPTION
## WP-C: Complete §1.21 — Remove remaining URSA_SSL env var fallback

PR #60 removed `legacy_cert_env_vars`/`legacy_key_env_vars` kwargs from the `resolve_https_certs()` call but left the manual `URSA_SSL_CERT_FILE → SSL_CERT_FILE` and `URSA_SSL_KEY_FILE → SSL_KEY_FILE` env var copying in `_resolve_https_cert_paths()`. This PR removes that last legacy fallback.

Standard `SSL_CERT_FILE`/`SSL_KEY_FILE` env vars remain fully supported.

### Verification
```bash
grep -rn 'URSA_SSL_CERT_FILE|URSA_SSL_KEY_FILE|legacy_cert|legacy_key' daylib_ursa/cli/server.py
# → 0 hits
```

All pre-commit checks pass.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author