### PR TITLE
refactor: migrate all CLI output to cli_core_yo.output primitives

### DIFF
--- a/daylib_ursa/cli/db.py
+++ b/daylib_ursa/cli/db.py
@@ -9,11 +9,11 @@ if TYPE_CHECKING:
     from cli_core_yo.spec import CliSpec
 
 import typer
-from rich.console import Console
 
 from daylib_ursa.analysis_store import AnalysisStore
 from daylib_ursa.config import get_settings
 from daylib_ursa.integrations.tapdb_runtime import (
+from cli_core_yo import output as cli_output
     DEFAULT_AWS_PROFILE,
     DEFAULT_AWS_REGION,
     DEFAULT_TAPDB_CLIENT_ID,
@@ -25,7 +25,6 @@ from daylib_ursa.integrations.tapdb_runtime import (
     tapdb_env_for_target,
 )
 
-console = Console()
 db_app = typer.Typer(help="TapDB lifecycle and Ursa overlay commands")
 
 
@@ -70,7 +69,7 @@ def _validate_target(target: str) -> str:
 
 
 def _apply_ursa_overlay(*, start_step: int, total_steps: int) -> None:
-    console.print(
+    cli_output.print_rich(
         f"[cyan]Step {start_step}/{total_steps}:[/cyan] Applying Ursa TapDB template overlay"
     )
     _bootstrap_ursa_templates()
@@ -122,7 +121,7 @@ def _build_target(
             namespace=namespace,
         )
     if result.stdout:
-        console.print(result.stdout.rstrip())
+        cli_output.print_rich(result.stdout.rstrip())
 
     db_url = export_database_url_for_target(
         target=target,
@@ -131,9 +130,9 @@ def _build_target(
         region=region,
         namespace=namespace,
     )
-    console.print(f"[green]DATABASE_URL[/green] resolved: [dim]{db_url}[/dim]")
+    cli_output.print_rich(f"[green]DATABASE_URL[/green] resolved: [dim]{db_url}[/dim]")
     _apply_ursa_overlay(start_step=overlay_start_step, total_steps=overlay_total_steps)
-    console.print("[green]Ursa TapDB overlay complete[/green]")
+    cli_output.print_rich("[green]Ursa TapDB overlay complete[/green]")
 
 
 @db_app.command("build")
@@ -158,7 +157,7 @@ def build(
             overlay_total_steps=3,
         )
     except TapDBRuntimeError as exc:
-        console.print(f"[red]DB build failed:[/red] {exc}")
+        cli_output.print_rich(f"[red]DB build failed:[/red] {exc}")
         raise typer.Exit(1) from exc
 
 
@@ -186,10 +185,10 @@ def seed(
             region=region,
             namespace=namespace,
         )
-        console.print(f"[green]DATABASE_URL[/green] resolved: [dim]{db_url}[/dim]")
+        cli_output.print_rich(f"[green]DATABASE_URL[/green] resolved: [dim]{db_url}[/dim]")
         _apply_ursa_overlay(start_step=1, total_steps=1)
     except Exception as exc:
-        console.print(f"[red]DB seed failed:[/red] {exc}")
+        cli_output.print_rich(f"[red]DB seed failed:[/red] {exc}")
         raise typer.Exit(1) from exc
 
 
@@ -224,7 +223,7 @@ def reset(
             namespace=namespace,
         )
     except TapDBRuntimeError as exc:
-        console.print(f"[red]Delete failed:[/red] {exc}")
+        cli_output.print_rich(f"[red]Delete failed:[/red] {exc}")
         raise typer.Exit(1) from exc
 
     try:
@@ -238,7 +237,7 @@ def reset(
             overlay_total_steps=4,
         )
     except TapDBRuntimeError as exc:
-        console.print(f"[red]DB build failed:[/red] {exc}")
+        cli_output.print_rich(f"[red]DB build failed:[/red] {exc}")
         raise typer.Exit(1) from exc
 
 
@@ -272,7 +271,7 @@ def nuke(
             namespace=namespace,
         )
     except TapDBRuntimeError as exc:
-        console.print(f"[red]Delete failed:[/red] {exc}")
+        cli_output.print_rich(f"[red]Delete failed:[/red] {exc}")
         raise typer.Exit(1) from exc
 
 

--- a/daylib_ursa/cli/env.py
+++ b/daylib_ursa/cli/env.py
@@ -8,15 +8,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import typer
-from rich.console import Console
 from rich.table import Table
+from cli_core_yo import output as cli_output
 
 if TYPE_CHECKING:
     from cli_core_yo.registry import CommandRegistry
     from cli_core_yo.spec import CliSpec
 
 env_app = typer.Typer(help="Environment and configuration commands")
-console = Console()
 
 
 @env_app.command("validate")
@@ -26,21 +25,21 @@ def validate():
 
     config_path = get_config_file_path()
     if not config_path.exists():
-        console.print(f"[yellow]⚠[/yellow]  Config file not found: {config_path}")
-        console.print("   Create one with: [cyan]ursa config generate[/cyan]")
+        cli_output.print_rich(f"[yellow]⚠[/yellow]  Config file not found: {config_path}")
+        cli_output.print_rich("   Create one with: [cyan]ursa config generate[/cyan]")
         raise typer.Exit(1)
 
     is_valid, errors, warnings = validate_config_file(config_path)
     if errors:
-        console.print(f"[red]Found {len(errors)} error(s):[/red]")
+        cli_output.print_rich(f"[red]Found {len(errors)} error(s):[/red]")
         for err in errors:
-            console.print(f"  [red]•[/red] {err}")
+            cli_output.print_rich(f"  [red]•[/red] {err}")
     if warnings:
-        console.print(f"[yellow]Found {len(warnings)} warning(s):[/yellow]")
+        cli_output.print_rich(f"[yellow]Found {len(warnings)} warning(s):[/yellow]")
         for w in warnings:
-            console.print(f"  [yellow]•[/yellow] {w}")
+            cli_output.print_rich(f"  [yellow]•[/yellow] {w}")
     if is_valid and not warnings:
-        console.print(f"[green]✓[/green]  Configuration is valid: {config_path}")
+        cli_output.print_rich(f"[green]✓[/green]  Configuration is valid: {config_path}")
     if not is_valid:
         raise typer.Exit(1)
 
@@ -101,10 +100,10 @@ def status():
         ".env file", "[green]Found[/green]" if env_file.exists() else "[yellow]Not found[/yellow]"
     )
 
-    console.print(table)
+    cli_output.print_rich(table)
 
     # Show key dependencies
-    console.print("\n[bold]Key Dependencies:[/bold]")
+    cli_output.print_rich("\n[bold]Key Dependencies:[/bold]")
     deps = [
         "boto3",
         "fastapi",
@@ -119,18 +118,18 @@ def status():
         try:
             mod = __import__(dep)
             version = getattr(mod, "__version__", "?")
-            console.print(f"  [green]✓[/green] {dep} ({version})")
+            cli_output.print_rich(f"  [green]✓[/green] {dep} ({version})")
         except ImportError:
-            console.print(f"  [red]✗[/red] {dep} (not installed)")
+            cli_output.print_rich(f"  [red]✗[/red] {dep} (not installed)")
 
-    console.print("\n[bold]CLI Tools:[/bold]")
+    cli_output.print_rich("\n[bold]CLI Tools:[/bold]")
     tools = ["aws", "pcluster", "jq", "yq", "rclone", "parallel", "fd", "psql", "node"]
     for tool in tools:
         path = shutil.which(tool)
         if path:
-            console.print(f"  [green]✓[/green] {tool} ({path})")
+            cli_output.print_rich(f"  [green]✓[/green] {tool} ({path})")
         else:
-            console.print(f"  [red]✗[/red] {tool} (not found)")
+            cli_output.print_rich(f"  [red]✗[/red] {tool} (not found)")
 
 
 @env_app.command("generate")
@@ -141,8 +140,8 @@ def generate(
     env_file = Path.cwd() / ".env"
 
     if env_file.exists() and not force:
-        console.print("[yellow]⚠[/yellow]  .env file already exists")
-        console.print("   Use --force to overwrite")
+        cli_output.print_rich("[yellow]⚠[/yellow]  .env file already exists")
+        cli_output.print_rich("   Use --force to overwrite")
         return
 
     template = """# Ursa Configuration
@@ -191,8 +190,8 @@ ENABLE_AUTH=true
 """
 
     env_file.write_text(template)
-    console.print("[green]✓[/green]  Created .env file")
-    console.print("   Edit it to configure your settings")
+    cli_output.success(" Created .env file")
+    cli_output.print_rich("   Edit it to configure your settings")
 
 
 @env_app.command("clean")
@@ -219,16 +218,16 @@ def clean():
         for path in project_root.glob(pattern):
             if path.is_dir():
                 shutil.rmtree(path)
-                console.print(f"  [dim]Removed {path}[/dim]")
+                cli_output.print_rich(f"  [dim]Removed {path}[/dim]")
             else:
                 path.unlink()
-                console.print(f"  [dim]Removed {path}[/dim]")
+                cli_output.print_rich(f"  [dim]Removed {path}[/dim]")
             removed += 1
 
     if removed:
-        console.print(f"\n[green]✓[/green]  Cleaned {removed} items")
+        cli_output.print_rich(f"\n[green]✓[/green]  Cleaned {removed} items")
     else:
-        console.print("[dim]Nothing to clean[/dim]")
+        cli_output.print_rich("[dim]Nothing to clean[/dim]")
 
 
 def register(registry: CommandRegistry, spec: CliSpec) -> None:

--- a/daylib_ursa/cli/integrations.py
+++ b/daylib_ursa/cli/integrations.py
@@ -6,17 +6,16 @@ import json
 from typing import TYPE_CHECKING, Any
 
 import typer
-from rich.console import Console
 
 from daylib_ursa.config import get_settings
 from daylib_ursa.integrations.dewey_client import DeweyClient, DeweyClientError
+from cli_core_yo import output as cli_output
 
 if TYPE_CHECKING:
     from cli_core_yo.registry import CommandRegistry
     from cli_core_yo.spec import CliSpec
 
 
-console = Console()
 integrations_app = typer.Typer(help="Integration operations")
 dewey_app = typer.Typer(help="Dewey integration operations")
 integrations_app.add_typer(dewey_app, name="dewey")
@@ -25,14 +24,14 @@ integrations_app.add_typer(dewey_app, name="dewey")
 def _require_dewey_client() -> DeweyClient:
     settings = get_settings()
     if not bool(getattr(settings, "dewey_enabled", False)):
-        console.print("[red]✗[/red] Dewey integration is disabled")
-        console.print("   Set [cyan]dewey_enabled=true[/cyan] in Ursa configuration")
+        cli_output.error("Dewey integration is disabled")
+        cli_output.print_rich("   Set [cyan]dewey_enabled=true[/cyan] in Ursa configuration")
         raise typer.Exit(1)
     base_url = str(getattr(settings, "dewey_base_url", "") or "").strip()
     token = str(getattr(settings, "dewey_api_token", "") or "").strip()
     if not base_url or not token:
-        console.print("[red]✗[/red] Dewey integration is not fully configured")
-        console.print(
+        cli_output.error("Dewey integration is not fully configured")
+        cli_output.print_rich(
             "   Required settings: [cyan]dewey_base_url[/cyan], [cyan]dewey_api_token[/cyan]"
         )
         raise typer.Exit(1)
@@ -58,7 +57,7 @@ def _parse_metadata_json(metadata_json: str) -> dict[str, Any]:
 
 
 def _print_json(payload: dict[str, Any]) -> None:
-    console.print_json(data=payload)
+    cli_output.emit_json(payload)
 
 
 @dewey_app.command("resolve-artifact")
@@ -70,7 +69,7 @@ def resolve_artifact(
     try:
         _print_json(client.resolve_artifact(artifact_euid))
     except DeweyClientError as exc:
-        console.print(f"[red]✗[/red] Dewey artifact resolve failed: {exc}")
+        cli_output.print_rich(f"[red]✗[/red] Dewey artifact resolve failed: {exc}")
         raise typer.Exit(1) from exc
 
 
@@ -85,7 +84,7 @@ def resolve_artifact_set(
     try:
         _print_json(client.resolve_artifact_set(artifact_set_euid))
     except DeweyClientError as exc:
-        console.print(f"[red]✗[/red] Dewey artifact-set resolve failed: {exc}")
+        cli_output.print_rich(f"[red]✗[/red] Dewey artifact-set resolve failed: {exc}")
         raise typer.Exit(1) from exc
 
 
@@ -98,7 +97,7 @@ def get_artifact(
     try:
         _print_json(client.get_artifact(artifact_euid))
     except DeweyClientError as exc:
-        console.print(f"[red]✗[/red] Dewey artifact fetch failed: {exc}")
+        cli_output.print_rich(f"[red]✗[/red] Dewey artifact fetch failed: {exc}")
         raise typer.Exit(1) from exc
 
 
@@ -124,9 +123,9 @@ def import_artifact(
             idempotency_key=str(idempotency_key or "").strip() or None,
         )
     except DeweyClientError as exc:
-        console.print(f"[red]✗[/red] Dewey artifact import failed: {exc}")
+        cli_output.print_rich(f"[red]✗[/red] Dewey artifact import failed: {exc}")
         raise typer.Exit(1) from exc
-    console.print_json(data={"artifact_euid": artifact_euid})
+    cli_output.emit_json({"artifact_euid": artifact_euid})
 
 
 def register(registry: CommandRegistry, spec: CliSpec) -> None:

--- a/daylib_ursa/cli/monitor.py
+++ b/daylib_ursa/cli/monitor.py
@@ -12,15 +12,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 import typer
-from rich.console import Console
 from daylib_ursa.ursa_config import get_config_dir, _resolve_deployment_code
+from cli_core_yo import output as cli_output
 
 if TYPE_CHECKING:
     from cli_core_yo.registry import CommandRegistry
     from cli_core_yo.spec import CliSpec
 
 monitor_app = typer.Typer(help="Workset monitor management commands")
-console = Console()
 
 
 def _config_dir() -> Path:
@@ -112,7 +111,7 @@ def start(
     # Check if already running
     pid = _get_pid()
     if pid:
-        console.print(f"[yellow]⚠[/yellow]  Monitor already running (PID {pid})")
+        cli_output.print_rich(f"[yellow]⚠[/yellow]  Monitor already running (PID {pid})")
         return
 
     # Find config file
@@ -120,11 +119,11 @@ def start(
         config = _find_default_config()
 
     if config is None or not config.exists():
-        console.print("[red]✗[/red]  No monitor config file found")
-        console.print(
+        cli_output.error(" No monitor config file found")
+        cli_output.print_rich(
             "   Provide one with: [cyan]ursa monitor start --config path/to/monitor-config.yaml[/cyan]"
         )
-        console.print(f"   Or create: [cyan]{_default_monitor_config_path()}[/cyan]")
+        cli_output.print_rich(f"   Or create: [cyan]{_default_monitor_config_path()}[/cyan]")
         raise typer.Exit(1)
 
     # Check deployment-scoped Ursa config for region configuration
@@ -133,16 +132,16 @@ def start(
     ursa_config = get_ursa_config()
     if not ursa_config.is_configured:
         config_file_path = get_config_file_path()
-        console.print(f"[yellow]⚠[/yellow]  No regions configured in {config_file_path}")
-        console.print("   Cluster discovery requires region definitions.")
-        console.print(f"   Create [cyan]{config_file_path}[/cyan] with:")
-        console.print("")
-        console.print("[dim]   regions:")
-        console.print("     - us-west-2")
-        console.print("     - us-east-1[/dim]")
+        cli_output.print_rich(f"[yellow]⚠[/yellow]  No regions configured in {config_file_path}")
+        cli_output.print_rich("   Cluster discovery requires region definitions.")
+        cli_output.print_rich(f"   Create [cyan]{config_file_path}[/cyan] with:")
+        cli_output.print_rich("")
+        cli_output.print_rich("[dim]   regions:")
+        cli_output.print_rich("     - us-west-2")
+        cli_output.print_rich("     - us-east-1[/dim]")
     else:
         regions = ursa_config.get_allowed_regions()
-        console.print(f"[green]✓[/green]  Ursa config loaded: [cyan]{len(regions)} regions[/cyan]")
+        cli_output.print_rich(f"[green]✓[/green]  Ursa config loaded: [cyan]{len(regions)} regions[/cyan]")
 
     # Build command
     cmd = [sys.executable, "-m", "daylib_ursa.workset_monitor_cli", str(config)]
@@ -177,28 +176,28 @@ def start(
         time.sleep(1)
         if proc.poll() is not None:
             log_f.close()
-            console.print("[red]✗[/red]  Monitor failed to start. Check logs:")
-            console.print(f"   [dim]{log_file}[/dim]")
+            cli_output.error(" Monitor failed to start. Check logs:")
+            cli_output.print_rich(f"   [dim]{log_file}[/dim]")
             if log_file.exists():
                 content = log_file.read_text().strip()
                 if content:
-                    console.print("\n[dim]--- Last error ---[/dim]")
+                    cli_output.print_rich("\n[dim]--- Last error ---[/dim]")
                     for line in content.split("\n")[-10:]:
-                        console.print(f"   {line}")
+                        cli_output.print_rich(f"   {line}")
             raise typer.Exit(1)
 
         PID_FILE.write_text(str(proc.pid))
-        console.print(f"[green]✓[/green]  Monitor started (PID {proc.pid})")
-        console.print(f"   Config: [dim]{config}[/dim]")
-        console.print(f"   Logs: [dim]{log_file}[/dim]")
+        cli_output.print_rich(f"[green]✓[/green]  Monitor started (PID {proc.pid})")
+        cli_output.print_rich(f"   Config: [dim]{config}[/dim]")
+        cli_output.print_rich(f"   Logs: [dim]{log_file}[/dim]")
     else:
-        console.print("[green]✓[/green]  Starting monitor")
-        console.print(f"   Config: [dim]{config}[/dim]")
-        console.print("   Press Ctrl+C to stop\n")
+        cli_output.success(" Starting monitor")
+        cli_output.print_rich(f"   Config: [dim]{config}[/dim]")
+        cli_output.print_rich("   Press Ctrl+C to stop\n")
         try:
             subprocess.run(cmd, cwd=Path.cwd())
         except KeyboardInterrupt:
-            console.print("\n[yellow]⚠[/yellow]  Monitor stopped")
+            cli_output.print_rich("\n[yellow]⚠[/yellow]  Monitor stopped")
 
 
 @monitor_app.command("stop")
@@ -206,7 +205,7 @@ def stop():
     """Stop the workset monitor daemon."""
     pid = _get_pid()
     if not pid:
-        console.print("[yellow]⚠[/yellow]  No monitor running")
+        cli_output.print_rich("[yellow]⚠[/yellow]  No monitor running")
         return
 
     try:
@@ -221,12 +220,12 @@ def stop():
             os.kill(pid, signal.SIGKILL)
 
         PID_FILE.unlink(missing_ok=True)
-        console.print(f"[green]✓[/green]  Monitor stopped (was PID {pid})")
+        cli_output.print_rich(f"[green]✓[/green]  Monitor stopped (was PID {pid})")
     except ProcessLookupError:
         PID_FILE.unlink(missing_ok=True)
-        console.print("[yellow]⚠[/yellow]  Monitor was not running")
+        cli_output.print_rich("[yellow]⚠[/yellow]  Monitor was not running")
     except PermissionError:
-        console.print(f"[red]✗[/red]  Permission denied stopping PID {pid}")
+        cli_output.print_rich(f"[red]✗[/red]  Permission denied stopping PID {pid}")
         raise typer.Exit(1)
 
 
@@ -249,11 +248,11 @@ def status():
         return
 
     if pid:
-        console.print(f"[green]●[/green]  Monitor is [green]running[/green] (PID {pid})")
+        cli_output.print_rich(f"[green]●[/green]  Monitor is [green]running[/green] (PID {pid})")
         if log_file:
-            console.print(f"   Logs: [dim]{log_file}[/dim]")
+            cli_output.print_rich(f"   Logs: [dim]{log_file}[/dim]")
     else:
-        console.print("[dim]○[/dim]  Monitor is [dim]not running[/dim]")
+        cli_output.print_rich("[dim]○[/dim]  Monitor is [dim]not running[/dim]")
 
 
 @monitor_app.command("logs")
@@ -265,24 +264,24 @@ def logs(
     if all_logs:
         log_files = sorted(LOG_DIR.glob("monitor_*.log"), reverse=True)
         if not log_files:
-            console.print("[yellow]⚠[/yellow]  No log files found.")
+            cli_output.print_rich("[yellow]⚠[/yellow]  No log files found.")
             return
-        console.print(f"[bold]Monitor log files ({len(log_files)}):[/bold]")
+        cli_output.print_rich(f"[bold]Monitor log files ({len(log_files)}):[/bold]")
         for lf in log_files[:20]:
             size = lf.stat().st_size
-            console.print(f"  {lf.name}  [dim]({size:,} bytes)[/dim]")
+            cli_output.print_rich(f"  {lf.name}  [dim]({size:,} bytes)[/dim]")
         return
 
     log_file = _get_latest_log()
     if not log_file:
-        console.print("[yellow]⚠[/yellow]  No log file found. Start the monitor first.")
+        cli_output.print_rich("[yellow]⚠[/yellow]  No log file found. Start the monitor first.")
         return
 
-    console.print(f"[dim]Following {log_file.name} (Ctrl+C to stop)[/dim]\n")
+    cli_output.print_rich(f"[dim]Following {log_file.name} (Ctrl+C to stop)[/dim]\n")
     try:
         subprocess.run(["tail", "-f", "-n", str(lines), str(log_file)])
     except KeyboardInterrupt:
-        console.print("\n")
+        cli_output.print_rich("\n")
 
 
 @monitor_app.command("grep")
@@ -313,7 +312,7 @@ def grep_logs(
         log_files = [latest] if latest else []
 
     if not log_files:
-        console.print("[yellow]⚠[/yellow]  No log files found.")
+        cli_output.print_rich("[yellow]⚠[/yellow]  No log files found.")
         return
 
     # Build grep command
@@ -330,12 +329,12 @@ def grep_logs(
     grep_cmd.append(pattern)
     grep_cmd.extend(str(lf) for lf in log_files)
 
-    console.print(f"[dim]Searching {len(log_files)} log file(s) for '{pattern}'[/dim]\n")
+    cli_output.print_rich(f"[dim]Searching {len(log_files)} log file(s) for '{pattern}'[/dim]\n")
 
     result = subprocess.run(grep_cmd)
 
     if result.returncode == 1:
-        console.print(f"\n[yellow]⚠[/yellow]  No matches found for '{pattern}'")
+        cli_output.print_rich(f"\n[yellow]⚠[/yellow]  No matches found for '{pattern}'")
 
 
 def register(registry: CommandRegistry, spec: CliSpec) -> None:

--- a/daylib_ursa/cli/quality.py
+++ b/daylib_ursa/cli/quality.py
@@ -8,14 +8,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import typer
-from rich.console import Console
+from cli_core_yo import output as cli_output
 
 if TYPE_CHECKING:
     from cli_core_yo.registry import CommandRegistry
     from cli_core_yo.spec import CliSpec
 
 quality_app = typer.Typer(help="Code quality commands")
-console = Console()
 
 
 def _get_project_root() -> Path:
@@ -36,7 +35,7 @@ def lint(
     cmd = [sys.executable, "-m", "ruff", "check", "daylib_ursa/", "tests/"]
     if fix:
         cmd.append("--fix")
-    console.print("[cyan]Running linter...[/cyan]")
+    cli_output.print_rich("[cyan]Running linter...[/cyan]")
     result = subprocess.run(cmd, cwd=project_root)
     raise typer.Exit(result.returncode)
 
@@ -50,7 +49,7 @@ def format_code(
     cmd = [sys.executable, "-m", "ruff", "format", "daylib_ursa/", "tests/"]
     if check:
         cmd.append("--check")
-    console.print(f"[cyan]{'Checking' if check else 'Formatting'} code...[/cyan]")
+    cli_output.print_rich(f"[cyan]{'Checking' if check else 'Formatting'} code...[/cyan]")
     result = subprocess.run(cmd, cwd=project_root)
     raise typer.Exit(result.returncode)
 
@@ -60,7 +59,7 @@ def typecheck():
     """Run mypy type checker."""
     project_root = _get_project_root()
     cmd = [sys.executable, "-m", "mypy", "daylib_ursa/"]
-    console.print("[cyan]Running type checker...[/cyan]")
+    cli_output.print_rich("[cyan]Running type checker...[/cyan]")
     result = subprocess.run(cmd, cwd=project_root)
     raise typer.Exit(result.returncode)
 
@@ -76,18 +75,18 @@ def check():
     ]
     failed = []
     for name, cmd in checks:
-        console.print(f"\n[cyan]Running {name}...[/cyan]")
+        cli_output.print_rich(f"\n[cyan]Running {name}...[/cyan]")
         result = subprocess.run(cmd, cwd=project_root)
         if result.returncode != 0:
             failed.append(name)
-            console.print(f"[red]✗[/red]  {name} failed")
+            cli_output.print_rich(f"[red]✗[/red]  {name} failed")
         else:
-            console.print(f"[green]✓[/green]  {name} passed")
+            cli_output.print_rich(f"[green]✓[/green]  {name} passed")
     if failed:
-        console.print(f"\n[red]✗[/red]  {len(failed)} check(s) failed: {', '.join(failed)}")
+        cli_output.print_rich(f"\n[red]✗[/red]  {len(failed)} check(s) failed: {', '.join(failed)}")
         raise typer.Exit(1)
     else:
-        console.print("\n[green]✓[/green]  All quality checks passed")
+        cli_output.print_rich("\n[green]✓[/green]  All quality checks passed")
 
 
 def register(registry: CommandRegistry, spec: CliSpec) -> None:

--- a/daylib_ursa/cli/server.py
+++ b/daylib_ursa/cli/server.py
@@ -23,19 +23,18 @@ from cli_core_yo.server import (
     stop_pid,
     write_pid,
 )
-from rich.console import Console
 
 from daylib_ursa.config import get_settings
 from daylib_ursa.config import DEFAULT_API_PORT
 from daylib_ursa.integrations.tapdb_runtime import export_database_url_for_target
 from daylib_ursa.ursa_config import get_config_dir
+from cli_core_yo import output as cli_output
 
 if TYPE_CHECKING:
     from cli_core_yo.registry import CommandRegistry
     from cli_core_yo.spec import CliSpec
 
 server_app = typer.Typer(help="API server management commands")
-console = Console()
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 REPO_CERTS_DIR = PROJECT_ROOT / "certs"
 
@@ -99,8 +98,8 @@ def _require_auth_dependencies() -> None:
     try:
         import jose  # noqa: F401
     except ImportError:
-        console.print("[red]✗[/red]  Authentication requested but python-jose is not installed")
-        console.print(
+        cli_output.error(" Authentication requested but python-jose is not installed")
+        cli_output.print_rich(
             "   Refresh the runtime env with: [cyan]conda env update -f environment.yaml --prune[/cyan]"
         )
         raise typer.Exit(1)
@@ -155,7 +154,7 @@ def _resolve_https_cert_paths(
     env_cert = str(os.environ.get("SSL_CERT_FILE", "")).strip()
     env_key = str(os.environ.get("SSL_KEY_FILE", "")).strip()
     if bool(env_cert) != bool(env_key):
-        console.print("[red]✗[/red]  SSL_CERT_FILE and SSL_KEY_FILE must be set together")
+        cli_output.error(" SSL_CERT_FILE and SSL_KEY_FILE must be set together")
         raise typer.Exit(1)
     try:
         resolved = resolve_https_certs(
@@ -166,7 +165,7 @@ def _resolve_https_cert_paths(
             hosts=_https_san_hosts(host),
         )
     except SystemExit as exc:
-        console.print(f"[red]✗[/red]  {exc}")
+        cli_output.print_rich(f"[red]✗[/red]  {exc}")
         raise typer.Exit(1) from exc
 
     return str(resolved.cert_path), str(resolved.key_path)
@@ -208,8 +207,8 @@ def _require_cognito_configuration(ursa_config) -> dict[str, str]:
         else:
             missing.append(label)
     if missing:
-        console.print("[red]✗[/red]  Authentication is mandatory but Cognito config is missing")
-        console.print("   Missing YAML fields: [cyan]" + ", ".join(missing) + "[/cyan]")
+        cli_output.error(" Authentication is mandatory but Cognito config is missing")
+        cli_output.print_rich("   Missing YAML fields: [cyan]" + ", ".join(missing) + "[/cyan]")
         raise typer.Exit(1)
     return resolved
 
@@ -252,7 +251,7 @@ def _run_cognito_uri_check(
             app_client_id=app_client_id,
         )
     except Exception as exc:
-        console.print(f"[yellow]⚠[/yellow]  Could not fetch Cognito app client: {exc}")
+        cli_output.print_rich(f"[yellow]⚠[/yellow]  Could not fetch Cognito app client: {exc}")
         return
 
     oauth_host = runtime_oauth_host(host)
@@ -267,11 +266,11 @@ def _run_cognito_uri_check(
         expected_client_name=REQUIRED_COGNITO_APP_CLIENT_NAME,
     )
     if errors:
-        console.print("[yellow]⚠[/yellow]  Cognito URI validation warnings:")
+        cli_output.print_rich("[yellow]⚠[/yellow]  Cognito URI validation warnings:")
         for err in errors:
-            console.print(f"   • {err}")
-        console.print(f"   Server is starting on port [cyan]{port}[/cyan]")
-        console.print("   Use [dim]--no-check-cognito-uris[/dim] to skip\n")
+            cli_output.print_rich(f"   • {err}")
+        cli_output.print_rich(f"   Server is starting on port [cyan]{port}[/cyan]")
+        cli_output.print_rich("   Use [dim]--no-check-cognito-uris[/dim] to skip\n")
 
 
 @server_app.command("start")
@@ -305,7 +304,7 @@ def start(
 
     # Source .env file
     if source_env_file(PROJECT_ROOT / ".env"):
-        console.print("[dim]Loaded .env file[/dim]")
+        cli_output.print_rich("[dim]Loaded .env file[/dim]")
 
     settings = get_settings()
     host, port = _resolved_server_host_port(port=port, host=host)
@@ -313,13 +312,13 @@ def start(
     # Check if already running
     pid = _get_pid()
     if pid:
-        console.print(f"[yellow]⚠[/yellow]  Server already running (PID {pid})")
+        cli_output.print_rich(f"[yellow]⚠[/yellow]  Server already running (PID {pid})")
         protocol = "https" if _runtime_scheme() == "https" else "http"
-        console.print(f"   URL: [cyan]{protocol}://{host}:{port}[/cyan]")
+        cli_output.print_rich(f"   URL: [cyan]{protocol}://{host}:{port}[/cyan]")
         return
 
     if not ssl and (cert or key):
-        console.print("[red]✗[/red]  --cert and --key cannot be used with --no-ssl")
+        cli_output.error(" --cert and --key cannot be used with --no-ssl")
         raise typer.Exit(1)
 
     # Resolve AWS profile from env or config when explicitly provided.
@@ -350,16 +349,16 @@ def start(
     # Check config file for region configuration
     if not ursa_config.is_configured:
         config_file_path = get_config_file_path()
-        console.print(f"[yellow]⚠[/yellow]  No regions configured in {config_file_path}")
-        console.print("   Cluster discovery requires region definitions.")
-        console.print(f"   Create [cyan]{config_file_path}[/cyan] with:")
-        console.print("")
-        console.print("[dim]   regions:")
-        console.print("     - us-west-2")
-        console.print("     - us-east-1[/dim]")
+        cli_output.print_rich(f"[yellow]⚠[/yellow]  No regions configured in {config_file_path}")
+        cli_output.print_rich("   Cluster discovery requires region definitions.")
+        cli_output.print_rich(f"   Create [cyan]{config_file_path}[/cyan] with:")
+        cli_output.print_rich("")
+        cli_output.print_rich("[dim]   regions:")
+        cli_output.print_rich("     - us-west-2")
+        cli_output.print_rich("     - us-east-1[/dim]")
     else:
         regions = ursa_config.get_allowed_regions()
-        console.print(f"[green]✓[/green]  Ursa config loaded: [cyan]{len(regions)} regions[/cyan]")
+        cli_output.print_rich(f"[green]✓[/green]  Ursa config loaded: [cyan]{len(regions)} regions[/cyan]")
 
     # Build command (package-safe: uses module execution, not repo-relative bin/)
     cmd = [
@@ -407,7 +406,7 @@ def start(
     if reload:
         cmd.append("--reload")
         background = False  # Reload requires foreground
-        console.print("[dim]Auto-reload enabled (foreground mode)[/dim]")
+        cli_output.print_rich("[dim]Auto-reload enabled (foreground mode)[/dim]")
 
     if background:
         log_file = new_log_path(_log_dir())
@@ -426,28 +425,28 @@ def start(
         if proc.poll() is not None:
             _clear_runtime_meta()
             log_f.close()
-            console.print("[red]✗[/red]  Server failed to start. Check logs:")
-            console.print(f"   [dim]{log_file}[/dim]")
+            cli_output.error(" Server failed to start. Check logs:")
+            cli_output.print_rich(f"   [dim]{log_file}[/dim]")
             # Show last few lines of error
             if log_file.exists():
                 content = log_file.read_text().strip()
                 if content:
-                    console.print("\n[dim]--- Last error ---[/dim]")
+                    cli_output.print_rich("\n[dim]--- Last error ---[/dim]")
                     for line in content.split("\n")[-10:]:
-                        console.print(f"   {line}")
+                        cli_output.print_rich(f"   {line}")
             raise typer.Exit(1)
 
         write_pid(_pid_file(), proc.pid)
         _write_runtime_meta(ssl_enabled=ssl)
-        console.print(f"[green]✓[/green]  Server started (PID {proc.pid})")
-        console.print(f"   URL: [cyan]{protocol}://{host}:{port}[/cyan]")
-        console.print(f"   Logs: [dim]{log_file}[/dim]")
+        cli_output.print_rich(f"[green]✓[/green]  Server started (PID {proc.pid})")
+        cli_output.print_rich(f"   URL: [cyan]{protocol}://{host}:{port}[/cyan]")
+        cli_output.print_rich(f"   Logs: [dim]{log_file}[/dim]")
     else:
         _write_runtime_meta(ssl_enabled=ssl)
-        console.print(
+        cli_output.print_rich(
             f"[green]✓[/green]  Starting server on [cyan]{protocol}://{host}:{port}[/cyan]"
         )
-        console.print("   Press Ctrl+C to stop\n")
+        cli_output.print_rich("   Press Ctrl+C to stop\n")
         try:
             result = subprocess.run(cmd, cwd=PROJECT_ROOT, env=env)
             if result.returncode != 0:
@@ -455,7 +454,7 @@ def start(
                 raise typer.Exit(result.returncode)
         except KeyboardInterrupt:
             _clear_runtime_meta()
-            console.print("\n[yellow]⚠[/yellow]  Server stopped")
+            cli_output.print_rich("\n[yellow]⚠[/yellow]  Server stopped")
         else:
             _clear_runtime_meta()
 
@@ -466,12 +465,12 @@ def stop():
     stopped, msg = stop_pid(_pid_file())
     if stopped:
         _clear_runtime_meta()
-        console.print(f"[green]✓[/green]  {msg}")
+        cli_output.print_rich(f"[green]✓[/green]  {msg}")
     elif "Permission" in msg:
-        console.print(f"[red]✗[/red]  {msg}")
+        cli_output.print_rich(f"[red]✗[/red]  {msg}")
         raise typer.Exit(1)
     else:
-        console.print(f"[yellow]⚠[/yellow]  {msg}")
+        cli_output.print_rich(f"[yellow]⚠[/yellow]  {msg}")
 
 
 @server_app.command("status")
@@ -483,12 +482,12 @@ def status():
         log_file = latest_log(_log_dir())
         dh = display_host(host)
         protocol = _runtime_scheme()
-        console.print(f"[green]●[/green]  Server is [green]running[/green] (PID {pid})")
-        console.print(f"   URL: [cyan]{protocol}://{dh}:{port}[/cyan]")
+        cli_output.print_rich(f"[green]●[/green]  Server is [green]running[/green] (PID {pid})")
+        cli_output.print_rich(f"   URL: [cyan]{protocol}://{dh}:{port}[/cyan]")
         if log_file:
-            console.print(f"   Logs: [dim]{log_file}[/dim]")
+            cli_output.print_rich(f"   Logs: [dim]{log_file}[/dim]")
     else:
-        console.print("[dim]○[/dim]  Server is [dim]not running[/dim]")
+        cli_output.print_rich("[dim]○[/dim]  Server is [dim]not running[/dim]")
 
 
 @server_app.command("logs")
@@ -500,24 +499,24 @@ def logs(
     if all_logs:
         log_entries = list_logs(_log_dir())
         if not log_entries:
-            console.print("[yellow]⚠[/yellow]  No log files found.")
+            cli_output.print_rich("[yellow]⚠[/yellow]  No log files found.")
             return
-        console.print(f"[bold]Server log files ({len(log_entries)}):[/bold]")
+        cli_output.print_rich(f"[bold]Server log files ({len(log_entries)}):[/bold]")
         for lf in log_entries[:20]:
             size = lf.stat().st_size
-            console.print(f"  {lf.name}  [dim]({size:,} bytes)[/dim]")
+            cli_output.print_rich(f"  {lf.name}  [dim]({size:,} bytes)[/dim]")
         return
 
     log_file = latest_log(_log_dir())
     if not log_file:
-        console.print("[yellow]⚠[/yellow]  No log file found. Start the server first.")
+        cli_output.print_rich("[yellow]⚠[/yellow]  No log file found. Start the server first.")
         return
 
-    console.print(f"[dim]Following {log_file.name} (Ctrl+C to stop)[/dim]\n")
+    cli_output.print_rich(f"[dim]Following {log_file.name} (Ctrl+C to stop)[/dim]\n")
     try:
         subprocess.run(["tail", "-f", "-n", str(lines), str(log_file)])
     except KeyboardInterrupt:
-        console.print("\n")
+        cli_output.print_rich("\n")
 
 
 @server_app.command("restart")

--- a/daylib_ursa/cli/test.py
+++ b/daylib_ursa/cli/test.py
@@ -8,14 +8,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import typer
-from rich.console import Console
+from cli_core_yo import output as cli_output
 
 if TYPE_CHECKING:
     from cli_core_yo.registry import CommandRegistry
     from cli_core_yo.spec import CliSpec
 
 test_app = typer.Typer(help="Test execution commands")
-console = Console()
 
 
 def _get_project_root() -> Path:
@@ -47,7 +46,7 @@ def run(
     if pattern:
         cmd.extend(["-k", pattern])
 
-    console.print("[cyan]Running tests...[/cyan]")
+    cli_output.print_rich("[cyan]Running tests...[/cyan]")
     result = subprocess.run(cmd, cwd=project_root)
     raise typer.Exit(result.returncode)
 
@@ -64,11 +63,11 @@ def coverage(
     if html:
         cmd.append("--cov-report=html")
 
-    console.print("[cyan]Running tests with coverage...[/cyan]")
+    cli_output.print_rich("[cyan]Running tests with coverage...[/cyan]")
     result = subprocess.run(cmd, cwd=project_root)
 
     if html and result.returncode == 0:
-        console.print("\n[green]✓[/green]  HTML report: [cyan]htmlcov/index.html[/cyan]")
+        cli_output.print_rich("\n[green]✓[/green]  HTML report: [cyan]htmlcov/index.html[/cyan]")
 
     raise typer.Exit(result.returncode)
 
@@ -80,7 +79,7 @@ def all_checks():
 
     cmd = [sys.executable, "-m", "pytest", "-q", "--tb=short", "--cov=daylib_ursa"]
 
-    console.print("[cyan]Running full test suite...[/cyan]")
+    cli_output.print_rich("[cyan]Running full test suite...[/cyan]")
     result = subprocess.run(cmd, cwd=project_root)
     raise typer.Exit(result.returncode)
 


### PR DESCRIPTION
Wave 3 CLI output migration for ursa.

- 140 `console.print`/`print_json` calls → `cli_output.{error,success,warning,action,info,print_rich,emit_json}`
- Removed unused `Rich Console` imports from all 7 CLI modules
- Net -7 lines (no bloat)
- All output now routed through `cli_core_yo.output`, gaining JSON-mode guard