### PR TITLE
Pin Ursa to daylily-tapdb 5.0.0

### DIFF
--- a/activate
+++ b/activate
@@ -25,7 +25,7 @@ URSA_LEGACY_REBIND_VARS=(
     USE_LOCAL_DAYLILY_COGNITO
 )
 URSA_REQUIRED_DISTRIBUTIONS=(
-    "daylily-tapdb==4.1.1"
+    "daylily-tapdb==5.0.0"
     "daylily-auth-cognito==2.0.1"
     "cli-core-yo==2.0.0"
 )

--- a/environment.yaml
+++ b/environment.yaml
@@ -24,7 +24,7 @@ dependencies:
       - sqlalchemy>=2.0.0
       - cli-core-yo==2.0.0
       - daylily-auth-cognito==2.0.1
-      - daylily-tapdb==4.1.1
+      - daylily-tapdb==5.0.0
       - fastapi>=0.104.0
       - uvicorn[standard]>=0.24.0
       - pydantic>=2.0.0
@@ -45,6 +45,7 @@ dependencies:
       - pytest-cov>=4.1.0
       - pytest-playwright>=0.4.4
       - playwright>=1.42.0
+      - build>=1.2.0
       - moto>=4.2.0
       - black>=23.0.0
       - ruff>=0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     # Cognito auth library
     "daylily-auth-cognito==2.0.1",
     # TapDB graph persistence
-    "daylily-tapdb==4.1.1",
+    "daylily-tapdb==5.0.0",
     "fastapi>=0.104.0",
     "uvicorn[standard]>=0.24.0",
     "pydantic>=2.0.0",

--- a/tests/test_activation_metadata.py
+++ b/tests/test_activation_metadata.py
@@ -23,7 +23,7 @@ def test_pyproject_uses_requested_internal_package_versions() -> None:
 
     assert "cli-core-yo==2.0.0" in dependencies
     assert "daylily-auth-cognito==2.0.1" in dependencies
-    assert "daylily-tapdb==4.1.1" in dependencies
+    assert "daylily-tapdb==5.0.0" in dependencies
     assert "daylily-ephemeral-cluster==0.7.614" in cluster_extra
 
 


### PR DESCRIPTION
Summary:\n- pin Ursa to daylily-tapdb==5.0.0\n- keep daylily-auth-cognito at 2.0.1 across activation and environment metadata\n\nValidation:\n- source ./activate local && python -m pytest tests/test_activation_metadata.py -q\n- pre-commit hooks passed but local pre-commit is installed in migration mode, so commit/push needed --no-verify after the checks ran