### PR TITLE
Release Daylily-Ursa 0.6.8 dependency pins

### DIFF
--- a/activate
+++ b/activate
@@ -22,11 +22,10 @@ CONDA_ENV_BASE="URSA"
 URSA_PIP_INSTALL_EXTRAS="[auth,dev]"
 URSA_LEGACY_REBIND_VARS=(
     USE_LOCAL_DAYLILY_TAPDB
-    USE_LOCAL_DAYLILY_COGNITO
 )
 URSA_REQUIRED_DISTRIBUTIONS=(
-    "daylily-tapdb==4.1.1"
-    "daylily-auth-cognito==2.0.1"
+    "daylily-tapdb==5.0.4"
+    "daylily-auth-cognito==2.0.2"
     "cli-core-yo==2.0.0"
 )
 URSA_REQUIRED_IMPORTS=(

--- a/config/ecosystem-versions.json
+++ b/config/ecosystem-versions.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "1",
-  "last_updated": "2026-04-02",
+  "last_updated": "2026-04-07",
   "components": {
     "daylily-ursa": {
       "repo": "Daylily-Informatics/daylily-ursa",
-      "current": "0.6.2"
+      "current": "0.6.8"
     },
     "daylily-ephemeral-cluster": {
       "repo": "Daylily-Informatics/daylily-ephemeral-cluster",
@@ -16,11 +16,11 @@
     },
     "daylily-auth-cognito": {
       "repo": "Daylily-Informatics/daylily-auth-cognito",
-      "current": "0.4.1"
+      "current": "2.0.2"
     },
     "daylily-tapdb": {
       "repo": "Daylily-Informatics/daylily-tapdb",
-      "current": "3.2.2"
+      "current": "5.0.4"
     },
     "daylily-omics-references": {
       "repo": "Daylily-Informatics/daylily-omics-references",

--- a/environment.yaml
+++ b/environment.yaml
@@ -23,8 +23,8 @@ dependencies:
       - pyyaml>=6.0
       - sqlalchemy>=2.0.0
       - cli-core-yo==2.0.0
-      - daylily-auth-cognito==2.0.1
-      - daylily-tapdb==4.1.1
+      - daylily-auth-cognito==2.0.2
+      - daylily-tapdb==5.0.4
       - fastapi>=0.104.0
       - uvicorn[standard]>=0.24.0
       - pydantic>=2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,9 @@ dependencies = [
     "sqlalchemy>=2.0.0",
     "cli-core-yo==2.0.0",
     # Cognito auth library
-    "daylily-auth-cognito==2.0.1",
+    "daylily-auth-cognito==2.0.2",
     # TapDB graph persistence
-    "daylily-tapdb==4.1.1",
+    "daylily-tapdb==5.0.4",
     "fastapi>=0.104.0",
     "uvicorn[standard]>=0.24.0",
     "pydantic>=2.0.0",

--- a/tests/test_activation_metadata.py
+++ b/tests/test_activation_metadata.py
@@ -22,8 +22,8 @@ def test_pyproject_uses_requested_internal_package_versions() -> None:
     cluster_extra = pyproject["project"]["optional-dependencies"]["cluster"]
 
     assert "cli-core-yo==2.0.0" in dependencies
-    assert "daylily-auth-cognito==2.0.1" in dependencies
-    assert "daylily-tapdb==4.1.1" in dependencies
+    assert "daylily-auth-cognito==2.0.2" in dependencies
+    assert "daylily-tapdb==5.0.4" in dependencies
     assert "daylily-ephemeral-cluster==0.7.614" in cluster_extra
 
 


### PR DESCRIPTION
## Summary
- pin daylily-auth-cognito==2.0.2
- pin daylily-tapdb==5.0.4
- pin cli-core-yo==2.0.0 across pyproject, environment, activate, and metadata
- remove the stale USE_LOCAL_DAYLILY_COGNITO activate rebinding

## Validation
- python -m pytest tests/test_activation_metadata.py tests/test_cli_registry_v2.py tests/test_console_scripts.py tests/test_cli_server_helpers.py -q
- python -m build
- python -m twine check dist/*