### PR TITLE
[codex] Refresh Ursa local walkthrough notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,20 @@ flowchart LR
 ```bash
 source ./activate <deploy-name>
 ursa config init
+ursa db build --target local
 ursa server start --port 8913
 ```
 
 `ursa server start` uses the shared TLS resolver by default. Pass `--no-ssl` for HTTP-only
 local testing, or `--cert` and `--key` to override the deployment-scoped cert pair.
+
+Current live caveats from the April 7, 2026 local walkthrough:
+
+- the missing-config hint from `ursa env validate` currently says `ursa config generate`, but the working command is `ursa config init`
+- GUI startup requires the Cognito values to exist in the YAML config itself; the current server preflight does not accept those fields from shell env overrides alone
+- populate these YAML fields before starting the GUI path:
+  `cognito_user_pool_id`, `cognito_app_client_id`, `cognito_region`, `cognito_domain`, `cognito_callback_url`, `cognito_logout_url`
+- `ursa config edit` is the repo-owned path for filling those fields
 
 Validation:
 

--- a/daylib_ursa/cli/monitor.py
+++ b/daylib_ursa/cli/monitor.py
@@ -145,8 +145,8 @@ def start(
         cli_output.print_rich(f"   Create [cyan]{config_file_path}[/cyan] with:")
         cli_output.print_rich("")
         cli_output.print_rich("[dim]   regions:")
-        cli_output.print_rich("     - us-west-2")
-        cli_output.print_rich("     - us-east-1[/dim]")
+        cli_output.print_rich("[dim]     - us-west-2[/dim]")
+        cli_output.print_rich("[dim]     - us-east-1[/dim]")
     else:
         regions = ursa_config.get_allowed_regions()
         cli_output.print_rich(


### PR DESCRIPTION
## Summary
- refresh the README local walkthrough notes for the current Ursa startup flow
- fix the region hint formatting in `daylib_ursa/cli/monitor.py`
- replace stale PR #71 with a fresh branch on the current release line

## Validation
- `python -m py_compile daylib_ursa/cli/monitor.py`